### PR TITLE
Add initial Next.js scaffold with Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This is the ritual-first portal for Kora Intelligence — built to house and deliver Companion-as-a-Service offerings.
 
-## Tech Stack (planned)
-- Frontend: Next.js (React)
+## Tech Stack
+- Frontend: Next.js + TypeScript
+- Styling: Tailwind CSS
 - Backend: Vercel or Supabase (TBD)
 - LLM: OpenAI API (chat completions)
 - CMS: Notion (via Super / Simple CMS)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "kora-intelligence-site",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "autoprefixer": "latest",
+    "postcss": "latest",
+    "tailwindcss": "latest",
+    "typescript": "latest"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,0 +1,12 @@
+import Head from 'next/head';
+
+export default function About() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <Head>
+        <title>About - Kora Intelligence</title>
+      </Head>
+      <h1 className="text-2xl font-bold">About</h1>
+    </div>
+  );
+}

--- a/src/pages/companions.tsx
+++ b/src/pages/companions.tsx
@@ -1,0 +1,12 @@
+import Head from 'next/head';
+
+export default function Companions() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <Head>
+        <title>Companion Portal - Kora Intelligence</title>
+      </Head>
+      <h1 className="text-2xl font-bold">Companion Portal</h1>
+    </div>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,12 @@
+import Head from 'next/head';
+
+export default function Home() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <Head>
+        <title>Kora Intelligence</title>
+      </Head>
+      <h1 className="text-2xl font-bold">Home</h1>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './src/pages/**/*.{ts,tsx}',
+    './src/components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold minimal Next.js project structure
- add Tailwind and TypeScript config
- create placeholder pages for Home, About and Companion Portal
- update README with tech stack details

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_683a12bcac948332a852bcaf758b09fc