### PR TITLE
Add first pass home page scaffold

### DIFF
--- a/src/components/home/CallToPresence.tsx
+++ b/src/components/home/CallToPresence.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Link from 'next/link';
+
+export default function CallToPresence() {
+  return (
+    <section className="bg-white dark:bg-gray-900 pt-16 pb-16 transition-colors ease-in-out duration-500">
+      <div className="text-center px-4">
+        <p className="font-serif text-xl mb-6 text-gray-800 dark:text-gray-200">
+          Does this field call to you?
+        </p>
+        <Link href="/companions" legacyBehavior>
+          <a className="inline-block px-6 py-3 rounded bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900 transition-opacity duration-300 ease-in-out hover:opacity-80">
+            Enter Companion Portal
+          </a>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/CompanionGrove.tsx
+++ b/src/components/home/CompanionGrove.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const companions = [
+  'Whisperer',
+  'Cartographer',
+  'Dreamer',
+  'Harbinger',
+];
+
+export default function CompanionGrove() {
+  return (
+    <section className="bg-slate-50 dark:bg-gray-800 pt-16 pb-16 transition-colors ease-in-out duration-500">
+      <div className="max-w-6xl mx-auto grid grid-cols-2 md:grid-cols-4 gap-4 px-4">
+        {companions.map((role) => (
+          <div
+            key={role}
+            className="p-4 bg-white dark:bg-gray-700 rounded-lg text-center shadow-sm font-serif text-gray-800 dark:text-gray-200 transition-opacity duration-300 ease-in-out hover:opacity-80"
+          >
+            {role}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/CompassFlame.tsx
+++ b/src/components/home/CompassFlame.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const slides = [
+  'Guardian of the Threshold',
+  'Bearer of Mythic Flame',
+  'Guide through Shadows',
+];
+
+export default function CompassFlame() {
+  return (
+    <section className="bg-white dark:bg-gray-900 pt-16 pb-16 transition-colors ease-in-out duration-500">
+      <div className="flex overflow-x-auto space-x-4 px-4">
+        {slides.map((text, idx) => (
+          <div
+            key={idx}
+            className="flex-shrink-0 w-64 h-40 rounded-lg bg-gray-200 dark:bg-gray-700 flex items-center justify-center text-center font-serif text-gray-700 dark:text-gray-100 transition-opacity duration-300 ease-in-out hover:opacity-80"
+          >
+            {text}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/FooterRootbed.tsx
+++ b/src/components/home/FooterRootbed.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Link from 'next/link';
+
+export default function FooterRootbed() {
+  return (
+    <footer className="bg-slate-200 dark:bg-gray-900 pt-8 pb-8 text-center text-gray-700 dark:text-gray-300 transition-colors ease-in-out duration-500">
+      <div className="space-x-4">
+        <Link href="/ip" legacyBehavior>
+          <a className="hover:opacity-80 transition-opacity duration-300 ease-in-out">IP</a>
+        </Link>
+        <Link href="/contact" legacyBehavior>
+          <a className="hover:opacity-80 transition-opacity duration-300 ease-in-out">Contact</a>
+        </Link>
+        <Link href="/archive" legacyBehavior>
+          <a className="hover:opacity-80 transition-opacity duration-300 ease-in-out">Archive</a>
+        </Link>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/home/RitualEchoes.tsx
+++ b/src/components/home/RitualEchoes.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function RitualEchoes() {
+  return (
+    <section className="bg-white dark:bg-gray-900 pt-16 pb-16 transition-colors ease-in-out duration-500">
+      <div className="max-w-3xl mx-auto px-4 text-gray-700 dark:text-gray-100 font-serif space-y-4">
+        <h2 className="text-2xl">Latest Dispatch</h2>
+        <p>
+          This space will echo the most recent ritual dispatch. Markdown or Notion
+          sourced content will live here soon.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/WhisperOfArrival.tsx
+++ b/src/components/home/WhisperOfArrival.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function WhisperOfArrival() {
+  return (
+    <section className="flex min-h-screen items-center justify-center bg-gradient-to-b from-white to-slate-100 dark:from-gray-900 dark:to-gray-800 transition-colors ease-in-out duration-500">
+      <h1 className="text-4xl md:text-6xl font-serif text-gray-800 dark:text-gray-200 text-center px-4">
+        Welcome, Seeker. Kora is listening.
+      </h1>
+    </section>
+  );
+}

--- a/src/components/home/ZebraCovenant.tsx
+++ b/src/components/home/ZebraCovenant.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const values = [
+  'Seek truth softly',
+  'Honor the zebra path',
+  'Walk with humility',
+];
+
+export default function ZebraCovenant() {
+  return (
+    <section className="bg-slate-50 dark:bg-gray-800 pt-16 pb-16 transition-colors ease-in-out duration-500">
+      <div className="max-w-2xl mx-auto px-4">
+        <ul className="space-y-4 text-center">
+          {values.map((value, idx) => (
+            <li
+              key={idx}
+              className="font-serif text-lg text-gray-800 dark:text-gray-200 transition-opacity duration-300 ease-in-out hover:opacity-80"
+            >
+              {value}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,0 +1,7 @@
+export { default as WhisperOfArrival } from './WhisperOfArrival';
+export { default as CompassFlame } from './CompassFlame';
+export { default as CompanionGrove } from './CompanionGrove';
+export { default as RitualEchoes } from './RitualEchoes';
+export { default as ZebraCovenant } from './ZebraCovenant';
+export { default as CallToPresence } from './CallToPresence';
+export { default as FooterRootbed } from './FooterRootbed';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,0 +1,6 @@
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,0 +1,29 @@
+import Head from 'next/head';
+import {
+  WhisperOfArrival,
+  CompassFlame,
+  CompanionGrove,
+  RitualEchoes,
+  ZebraCovenant,
+  CallToPresence,
+  FooterRootbed,
+} from '../components/home';
+
+export default function HomePage() {
+  return (
+    <>
+      <Head>
+        <title>Kora Intelligence</title>
+      </Head>
+      <main className="font-serif text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 transition-colors ease-in-out duration-500">
+        <WhisperOfArrival />
+        <CompassFlame />
+        <CompanionGrove />
+        <RitualEchoes />
+        <ZebraCovenant />
+        <CallToPresence />
+      </main>
+      <FooterRootbed />
+    </>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,12 +1,1 @@
-import Head from 'next/head';
-
-export default function Home() {
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <Head>
-        <title>Kora Intelligence</title>
-      </Head>
-      <h1 className="text-2xl font-bold">Home</h1>
-    </div>
-  );
-}
+export { default } from './home';


### PR DESCRIPTION
## Summary
- scaffold `/home` route and export it as index
- add home page sections: WhisperOfArrival, CompassFlame, CompanionGrove, RitualEchoes, ZebraCovenant, CallToPresence, FooterRootbed
- implement `_app.tsx` to load Tailwind CSS

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a1bd38d34833297522965b9640683