### PR TITLE
Fix WhisperOfArrival markup

### DIFF
--- a/src/components/home/WhisperOfArrival.tsx
+++ b/src/components/home/WhisperOfArrival.tsx
@@ -2,14 +2,11 @@
 
 export default function WhisperOfArrival() {
   return (
-<section
-  aria-label="Welcome Invocation"
-  className="flex min-h-screen items-center justify-center bg-gradient-to-b from-white to-slate-100 dark:from-gray-900 dark:to-gray-800 transition-colors ease-in-out duration-500"
->
-  <h1 className="text-4xl md:text-6xl font-serif text-gray-800 dark:text-gray-200 text-center px-4">
-    Welcome, Seeker. Kora is listening.
-  </h1>
-</section>
+    <section
+      aria-label="Welcome Invocation"
+      className="flex min-h-screen items-center justify-center bg-gradient-to-b from-white to-slate-100 dark:from-gray-900 dark:to-gray-800 transition-colors ease-in-out duration-500"
+    >
+      <h1 className="text-4xl md:text-6xl font-serif text-gray-800 dark:text-gray-200 text-center px-4">
         Welcome, Seeker. Kora is listening.
       </h1>
     </section>


### PR DESCRIPTION
## Summary
- clean up leftover conflict code in `WhisperOfArrival`

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a4b93050c83328fc5aae4b795885a