### PR TITLE
Fix tailwindcss postcss plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "react-dom": "latest"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "latest",
     "@types/node": "^22.15.29",
     "@types/react": "^19.1.6",
     "autoprefixer": "latest",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` plugin in PostCSS config
- add `@tailwindcss/postcss` to dev dependencies

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a5cb4197083328b847c20036f5a55