### PR TITLE
Implement global layout with header/footer and new 404 page

### DIFF
--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -4,4 +4,3 @@ export { default as CompanionGrove } from './CompanionGrove';
 export { default as RitualEchoes } from './RitualEchoes';
 export { default as ZebraCovenant } from './ZebraCovenant';
 export { default as CallToPresence } from './CallToPresence';
-export { default as FooterRootbed } from './FooterRootbed';

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="bg-emerald-950 text-emerald-200 text-center py-6 text-sm font-serif">
+      Rooted in myth. Guided by listening.
+    </footer>
+  );
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <nav className="bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow sticky top-0 z-50">
+      <div className="max-w-6xl mx-auto flex justify-between items-center py-4 px-6">
+        <div className="text-xl font-serif">Kora Intelligence</div>
+        <div className="space-x-6 text-sm font-medium">
+          <Link href="/">Home</Link>
+          <Link href="/companions">Companions</Link>
+          <Link href="/support">Support</Link>
+          <Link href="/dispatch">Dispatch</Link>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function NotFoundPage() {
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-neutral-50 dark:bg-neutral-900 text-center px-6 space-y-6">
+      <div className="text-6xl">🌀</div>
+      <h1 className="text-3xl text-amber-600 font-semibold">This path hasn’t been drawn yet.</h1>
+      <p className="text-gray-700 dark:text-gray-200 font-serif">You’ve reached a quiet clearing. Return when the way reveals itself.</p>
+      <Link href="/" className="text-indigo-600 hover:underline">Return Home</Link>
+    </main>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,14 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
+import Header from '../components/layout/Header';
+import Footer from '../components/layout/Footer';
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Header />
+      <Component {...pageProps} />
+      <Footer />
+    </>
+  );
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -6,7 +6,6 @@ import {
   RitualEchoes,
   ZebraCovenant,
   CallToPresence,
-  FooterRootbed,
 } from '../components/home';
 
 export default function HomePage() {
@@ -23,7 +22,6 @@ export default function HomePage() {
         <ZebraCovenant />
         <CallToPresence />
       </main>
-      <FooterRootbed />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add layout Header with navigation links
- add Footer rootbed component
- integrate layout into `_app`
- add a styled 404 page
- clean up old footer usage

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683ce6bbfa808332b9e1cd5c30ccb664