### PR TITLE
Improve mobile navigation and styling

### DIFF
--- a/src/components/home/CallToPresence.tsx
+++ b/src/components/home/CallToPresence.tsx
@@ -12,7 +12,7 @@ export default function CallToPresence() {
           Does this field call to you?
         </p>
         <Link href="/companions" legacyBehavior>
-          <a className="inline-block px-4 py-2 text-sm sm:text-base rounded transition-opacity hover:opacity-80 bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900">
+          <a className="inline-block bg-amber-100 hover:bg-amber-200 text-gray-900 font-medium py-2 px-4 rounded-lg transition-colors duration-300 ease-in-out text-sm sm:text-base">
             Enter Companion Portal
           </a>
         </Link>

--- a/src/components/home/CompanionGrove.tsx
+++ b/src/components/home/CompanionGrove.tsx
@@ -20,16 +20,15 @@ export default function CompanionGrove() {
     >
       <div className="max-w-6xl mx-auto grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
         {companions.map((companion) => (
-          <div
+          <Link
             key={companion.slug}
-            className="p-6 bg-white dark:bg-emerald-950 rounded-2xl text-center shadow-sm font-serif text-gray-900 dark:text-emerald-200 transition duration-300 ease-in-out hover:opacity-80 transform hover:scale-105"
+            href={`/companions/${companion.slug}`}
+            legacyBehavior
           >
-            <Link href={`/companions/${companion.slug}`} legacyBehavior>
-              <a className="text-amber-600 text-lg font-serif hover:text-indigo-600 hover:underline transition-opacity duration-300 ease-in-out">
-                {companion.label}
-              </a>
-            </Link>
-          </div>
+            <a className="block p-4 py-3 px-4 text-base sm:text-lg bg-emerald-950 text-emerald-100 hover:bg-emerald-800 transition-all rounded-lg text-center shadow-sm font-serif hover:shadow-lg">
+              {companion.label}
+            </a>
+          </Link>
         ))}
       </div>
     </section>

--- a/src/components/home/ZebraCovenant.tsx
+++ b/src/components/home/ZebraCovenant.tsx
@@ -13,11 +13,11 @@ export default function ZebraCovenant() {
       className="bg-slate-50 dark:bg-gray-800 px-4 sm:px-6 md:px-8 pt-16 pb-16 transition-colors ease-in-out duration-500"
     >
       <div className="max-w-3xl mx-auto space-y-4">
-        <ul className="space-y-4 text-center">
+        <ul className="space-y-4 text-center max-w-sm mx-auto text-gray-800 dark:text-gray-100 font-serif">
           {values.map((value, idx) => (
             <li
               key={idx}
-              className="font-serif text-lg text-gray-800 dark:text-gray-200 transition-opacity duration-300 ease-in-out hover:opacity-80"
+              className="text-lg transition-opacity duration-300 ease-in-out hover:opacity-80"
             >
               {value}
             </li>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,19 +1,46 @@
+import { useState } from 'react';
 import Link from 'next/link';
 
-// TODO: Add mobile nav toggle with Headless UI
-
 export default function Header() {
+  const [open, setOpen] = useState(false);
+
   return (
     <nav className="bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow sticky top-0 z-50">
       <div className="max-w-6xl mx-auto flex justify-between items-center py-4 px-6">
         <div className="text-xl font-serif">Kora Intelligence</div>
-        <div className="space-x-6 text-sm font-medium">
-          <Link href="/">Home</Link>
-          <Link href="/companions">Companions</Link>
-          <Link href="/support">Support</Link>
-          <Link href="/dispatch">Dispatch</Link>
+        <div className="flex items-center">
+          <button
+            aria-label="Toggle menu"
+            onClick={() => setOpen(!open)}
+            className="sm:hidden focus:outline-none"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5h16.5M3.75 12h16.5m-16.5 7.5h16.5" />
+            </svg>
+          </button>
+          <div className="hidden sm:flex space-x-6 text-sm font-medium">
+            <Link href="/">Home</Link>
+            <Link href="/companions">Companions</Link>
+            <Link href="/support">Support</Link>
+            <Link href="/dispatch">Dispatch</Link>
+          </div>
         </div>
       </div>
+      {open && (
+        <div className="sm:hidden transition-all bg-white dark:bg-gray-900 space-y-2 text-center py-4">
+          <Link href="/" onClick={() => setOpen(false)}>Home</Link>
+          <Link href="/companions" onClick={() => setOpen(false)}>Companions</Link>
+          <Link href="/support" onClick={() => setOpen(false)}>Support</Link>
+          <Link href="/dispatch" onClick={() => setOpen(false)}>Dispatch</Link>
+        </div>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
## Summary
- refine `Header` with a mobile dropdown menu
- adjust `CompanionGrove` buttons for touch friendliness
- highlight the call-to-presence CTA
- center the Zebra Covenant list

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683d82ef442c83329af134bb355a869a