### PR TITLE
Add Signal the Grove support page

### DIFF
--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,0 +1,31 @@
+import Head from 'next/head';
+
+export default function Support() {
+  return (
+    <>
+      <Head>
+        <title>Signal the Grove – Kora Intelligence</title>
+        <meta name="description" content="Reach out to the Grove with intention or inquiry." />
+      </Head>
+      <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-12 text-center font-serif text-gray-800 dark:text-gray-100">
+        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">
+          Signal the Grove
+        </h1>
+        <p className="text-lg sm:text-xl italic">
+          Share what stirs, ask what calls, or simply name your presence.
+        </p>
+        <div className="mt-12">
+          <iframe
+            src="https://tally.so/r/wo1N01"
+            loading="lazy"
+            width="100%"
+            height="600"
+            frameBorder="0"
+            title="Signal the Grove Form"
+            className="rounded-xl border-2 border-amber-200"
+          ></iframe>
+        </div>
+      </main>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/support` route
- embed Tally.so form for contacting the Grove

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683df61b4e1c8332a8d5a763c3bdf915