### PR TITLE
Add About link to navigation

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -12,6 +12,9 @@ export default function Footer() {
       />
       <p className="text-emerald-100">Rooted in myth. Guided by listening.</p>
       <p className="text-emerald-300">A project of <span className="underline">Paths Unknown</span></p>
+      <Link href="/about" className="text-emerald-200 underline hover:text-amber-200">
+        About Kora
+      </Link>
     </footer>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -28,6 +28,7 @@ export default function Header() {
           <Link href="/companions">Companions</Link>
           <Link href="/support">Support</Link>
           <Link href="/dispatch">Dispatch</Link>
+          <Link href="/about">About</Link>
         </div>
 
         {/* Mobile Toggle Button */}
@@ -56,6 +57,7 @@ export default function Header() {
           <Link href="/companions" onClick={() => setOpen(false)}>Companions</Link>
           <Link href="/support" onClick={() => setOpen(false)}>Support</Link>
           <Link href="/dispatch" onClick={() => setOpen(false)}>Dispatch</Link>
+          <Link href="/about" onClick={() => setOpen(false)}>About</Link>
         </div>
       )}
     </nav>


### PR DESCRIPTION
## Summary
- make About page visible in header nav on desktop and mobile
- add optional About Kora link in footer

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_683e05b794b48332b511cccc45d2aec9