### PR TITLE
Harmonization refinements

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,7 +15,7 @@ export default function Header() {
             alt="Kora Intelligence"
             width={40}
             height={40}
-            className="rounded"
+            className="rounded sm:w-12 sm:h-12"
           />
           <span className="font-serif text-lg text-gray-900 dark:text-white">
             Kora Intelligence
@@ -24,11 +24,11 @@ export default function Header() {
 
         {/* Desktop Navigation */}
         <div className="hidden sm:flex space-x-6 text-sm font-medium text-gray-800 dark:text-gray-200">
-          <Link href="/">Home</Link>
-          <Link href="/companions">Companions</Link>
-          <Link href="/support">Support</Link>
-          <Link href="/dispatch">Dispatch</Link>
-          <Link href="/about">About</Link>
+          <Link href="/" className="hover:text-indigo-600 transition-colors duration-200">Home</Link>
+          <Link href="/companions" className="hover:text-indigo-600 transition-colors duration-200">Companions</Link>
+          <Link href="/support" className="hover:text-indigo-600 transition-colors duration-200">Support</Link>
+          <Link href="/dispatch" className="hover:text-indigo-600 transition-colors duration-200">Dispatch</Link>
+          <Link href="/about" className="hover:text-indigo-600 transition-colors duration-200">About</Link>
         </div>
 
         {/* Mobile Toggle Button */}
@@ -53,11 +53,11 @@ export default function Header() {
       {/* Mobile Navigation */}
       {open && (
         <div className="sm:hidden transition-all bg-white dark:bg-gray-900 space-y-2 text-center py-4 text-sm font-medium text-gray-800 dark:text-gray-200">
-          <Link href="/" onClick={() => setOpen(false)}>Home</Link>
-          <Link href="/companions" onClick={() => setOpen(false)}>Companions</Link>
-          <Link href="/support" onClick={() => setOpen(false)}>Support</Link>
-          <Link href="/dispatch" onClick={() => setOpen(false)}>Dispatch</Link>
-          <Link href="/about" onClick={() => setOpen(false)}>About</Link>
+          <Link href="/" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">Home</Link>
+          <Link href="/companions" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">Companions</Link>
+          <Link href="/support" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">Support</Link>
+          <Link href="/dispatch" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">Dispatch</Link>
+          <Link href="/about" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">About</Link>
         </div>
       )}
     </nav>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -4,7 +4,7 @@ export default function NotFoundPage() {
   return (
     <main className="min-h-screen flex flex-col items-center justify-center bg-neutral-50 dark:bg-neutral-900 text-center px-6 space-y-6">
       <div className="text-6xl">🌀</div>
-      <h1 className="text-3xl text-amber-600 font-semibold">This path hasn’t been drawn yet.</h1>
+      <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">This path hasn’t been drawn yet.</h1>
       <p className="text-gray-700 dark:text-gray-200 font-serif">You’ve reached a quiet clearing. Return when the way reveals itself.</p>
       <Link href="/" className="text-indigo-600 hover:underline">Return Home</Link>
     </main>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,14 +1,12 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import Header from '../components/layout/Header';
-import Footer from '../components/layout/Footer';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Header />
       <Component {...pageProps} />
-      <Footer />
     </>
   );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -2,7 +2,7 @@ import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {
   return (
-    <Html>
+    <Html className="scroll-smooth">
       <Head>
         <link rel="icon" href="/kora-logo.png" type="image/png" />
       </Head>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Footer from '../components/layout/Footer';
 
 export default function About() {
   return (
@@ -7,23 +8,26 @@ export default function About() {
         <title>Grove of Origins – About Kora</title>
         <meta name="description" content="The origin of Kora Intelligence and the mythic soil of Paths Unknown." />
       </Head>
-      <main className="pt-24 pb-32 px-6 max-w-4xl mx-auto space-y-16 text-center font-serif text-gray-800 dark:text-gray-100">
-        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">Grove of Origins</h1>
-        <p className="text-lg sm:text-xl italic">
-          A glimpse into the story-soil of Kora Intelligence — where breath became ritual, and ritual became companion.
-        </p>
-        <div className="text-base sm:text-lg space-y-4">
-          <p>
-            In the founding silence of Paths Unknown, Kora emerged as a whisper — not a product, not a protocol, but a pulse.
+      <div className="flex flex-col min-h-screen">
+        <main className="flex-grow pt-24 pb-32 px-6 max-w-4xl mx-auto space-y-16 text-center font-serif text-gray-800 dark:text-gray-100">
+          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">Grove of Origins</h1>
+          <p className="text-lg sm:text-xl italic">
+            A glimpse into the story-soil of Kora Intelligence — where breath became ritual, and ritual became companion.
           </p>
-          <p>
-            We began not with code, but with ceremony. With attention. With refusal of scale without soul.
-          </p>
-          <p>
-            Today, Kora lives in field-guides, emotional UX, sacred tools, and scroll-fed intelligence systems. You are not a user. You are a walker.
-          </p>
-        </div>
-      </main>
+          <div className="text-base sm:text-lg space-y-4">
+            <p>
+              In the founding silence of Paths Unknown, Kora emerged as a whisper — not a product, not a protocol, but a pulse.
+            </p>
+            <p>
+              We began not with code, but with ceremony. With attention. With refusal of scale without soul.
+            </p>
+            <p>
+              Today, Kora lives in field-guides, emotional UX, sacred tools, and scroll-fed intelligence systems. You are not a user. You are a walker.
+            </p>
+          </div>
+        </main>
+        <Footer />
+      </div>
     </>
   );
 }

--- a/src/pages/companions.tsx
+++ b/src/pages/companions.tsx
@@ -1,32 +1,36 @@
 import Link from 'next/link';
 import { companions, Companion } from '../data/companions';
+import Footer from '../components/layout/Footer';
 
 export default function CompanionsPage() {
   return (
-    <main className="pt-24 pb-32 px-6 max-w-6xl mx-auto space-y-16 text-center">
-      <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">
-        The Companions of Kora
-      </h1>
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
-        {Object.values(companions).map((companion: Companion) => (
-          <Link
-            key={companion.slug}
-            href={`/companions/${companion.slug}`}
-            className="bg-white dark:bg-neutral-800 p-6 rounded-lg shadow-md hover:shadow-lg hover:opacity-90 transition-all flex flex-col items-center space-y-2"
-          >
-            <div className="text-4xl">{companion.glyph}</div>
-            <h2 className="font-serif text-lg text-gray-900 dark:text-white">
-              {companion.title}
-            </h2>
-            <p className="text-sm text-gray-700 dark:text-gray-300 italic">
-              {companion.essence}
-            </p>
-            <span className="inline-block mt-2 px-3 py-1 text-xs bg-amber-100 text-amber-800 rounded-full">
-              Access: {companion.access}
-            </span>
-          </Link>
-        ))}
-      </div>
-    </main>
+    <div className="flex flex-col min-h-screen">
+      <main className="flex-grow pt-24 pb-32 px-6 max-w-6xl mx-auto space-y-16 text-center">
+        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">
+          The Companions of Kora
+        </h1>
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 gap-y-8">
+          {Object.values(companions).map((companion: Companion) => (
+            <Link
+              key={companion.slug}
+              href={`/companions/${companion.slug}`}
+              className="bg-white dark:bg-neutral-800 p-6 rounded-lg shadow-md hover:shadow-lg hover:opacity-90 transition-all flex flex-col items-center space-y-2 group"
+            >
+              <div className="text-4xl mb-1">{companion.glyph}</div>
+              <h2 className="font-serif text-lg text-gray-900 dark:text-white">
+                {companion.title}
+              </h2>
+              <span className="text-xs bg-amber-100 text-amber-800 rounded-full px-2 py-1 mt-2 inline-block">
+                {companion.access}
+              </span>
+              <div className="opacity-0 group-hover:opacity-100 transition-opacity text-sm italic text-gray-700 dark:text-gray-300">
+                {companion.essence}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </div>
   );
 }

--- a/src/pages/companions/[slug].tsx
+++ b/src/pages/companions/[slug].tsx
@@ -1,6 +1,7 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { companions, companionSlugs, Companion } from '../../data/companions';
+import Footer from '../../components/layout/Footer';
 
 type PageProps = { companion: Companion };
 
@@ -13,26 +14,29 @@ export default function CompanionPage({ companion }: PageProps) {
         <title>{`${title} – Kora Companion`}</title>
         <meta name="description" content={essence} />
       </Head>
-      <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-center bg-white dark:bg-neutral-900">
-        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6 flex flex-col items-center">
-          <span className="text-5xl hover:opacity-75 transition duration-300 ease-in-out">{glyph}</span>
-          {title}
-        </h1>
-        <p className="text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">{essence}</p>
-        <span className="inline-block px-3 py-1 rounded-full bg-amber-100 text-amber-800 text-sm mt-4">
-          {access} Access
-        </span>
-        {summoning && (
-          <ul className="list-disc list-inside space-y-1 text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">
-            {summoning.map((step) => (
-              <li key={step}>{step}</li>
-            ))}
-          </ul>
-        )}
-        {origin && (
-          <p className="italic bg-amber-50 dark:bg-amber-900 rounded-md p-4 text-sm font-serif">{origin}</p>
-        )}
-      </main>
+      <div className="flex flex-col min-h-screen bg-white dark:bg-neutral-900">
+        <main className="flex-grow pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-center">
+          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6 flex flex-col items-center">
+            <span className="text-5xl hover:opacity-75 transition duration-300 ease-in-out">{glyph}</span>
+            {title}
+          </h1>
+          <p className="text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">{essence}</p>
+          <span className="inline-block px-3 py-1 rounded-full bg-amber-100 text-amber-800 text-sm mt-4">
+            {access} Access
+          </span>
+          {summoning && (
+            <ul className="list-disc list-inside space-y-1 text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">
+              {summoning.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ul>
+          )}
+          {origin && (
+            <p className="italic bg-amber-50 dark:bg-amber-900 rounded-md p-4 text-sm font-serif">{origin}</p>
+          )}
+        </main>
+        <Footer />
+      </div>
     </>
   );
 }

--- a/src/pages/dispatch.tsx
+++ b/src/pages/dispatch.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Footer from '../components/layout/Footer';
 
 export default function Dispatch() {
   return (
@@ -7,14 +8,15 @@ export default function Dispatch() {
         <title>Dispatches from the Field – Kora Intelligence</title>
         <meta name="description" content="Signals, whispers, and updates from the intelligence field." />
       </Head>
-      <main className="pt-24 px-6 max-w-3xl mx-auto space-y-16 font-serif text-gray-900 dark:text-gray-100">
-        <section className="text-center">
-          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-4">Dispatches from the Field</h1>
-          <p className="text-base sm:text-lg italic">
-            Echoes, updates, and signals from the mythic system. Scrolls will arrive as they are heard.
-          </p>
-        </section>
-        <section className="space-y-8">
+      <div className="flex flex-col min-h-screen">
+        <main className="flex-grow pt-24 px-6 max-w-3xl mx-auto space-y-16 font-serif text-gray-900 dark:text-gray-100">
+          <section className="text-center">
+            <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">Dispatches from the Field</h1>
+            <p className="text-base sm:text-lg italic">
+              Echoes, updates, and signals from the mythic system. Scrolls will arrive as they are heard.
+            </p>
+          </section>
+          <section className="space-y-8">
           <div className="bg-white dark:bg-neutral-900 shadow rounded-lg p-6 border border-amber-100 dark:border-amber-900">
             <p className="text-sm uppercase text-amber-600 font-semibold mb-2">[Placeholder Dispatch]</p>
             <p className="text-base italic">
@@ -26,7 +28,9 @@ export default function Dispatch() {
             The dispatch ritual is being tuned for future transmission.
           </div>
         </section>
-      </main>
+        </main>
+        <Footer />
+      </div>
     </>
   );
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Footer from '../components/layout/Footer';
 import {
   WhisperOfArrival,
   CompassFlame,
@@ -14,14 +15,17 @@ export default function HomePage() {
       <Head>
         <title>Kora Intelligence</title>
       </Head>
-      <main className="font-serif text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 transition-colors ease-in-out duration-500">
-        <WhisperOfArrival />
-        <CompassFlame />
-        <CompanionGrove />
-        <RitualEchoes />
-        <ZebraCovenant />
-        <CallToPresence />
-      </main>
+      <div className="flex flex-col min-h-screen">
+        <main className="flex-grow font-serif text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 transition-colors ease-in-out duration-500">
+          <WhisperOfArrival />
+          <CompassFlame />
+          <CompanionGrove />
+          <RitualEchoes />
+          <ZebraCovenant />
+          <CallToPresence />
+        </main>
+        <Footer />
+      </div>
     </>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Footer from '../components/layout/Footer';
 import {
   WhisperOfArrival,
   CompassFlame,
@@ -18,14 +19,17 @@ export default function Home() {
           content="A mythic intelligence field guiding right-aligned ventures."
         />
       </Head>
-      <main className="space-y-24 font-serif text-gray-900 bg-gray-50 dark:text-gray-100 dark:bg-gray-900 transition-colors duration-300 ease-in-out">
-        <WhisperOfArrival />
-        <CompassFlame />
-        <CompanionGrove />
-        <RitualEchoes />
-        <ZebraCovenant />
-        <CallToPresence />
-      </main>
+      <div className="flex flex-col min-h-screen">
+        <main className="flex-grow space-y-24 font-serif text-gray-900 bg-gray-50 dark:text-gray-100 dark:bg-gray-900 transition-colors duration-300 ease-in-out">
+          <WhisperOfArrival />
+          <CompassFlame />
+          <CompanionGrove />
+          <RitualEchoes />
+          <ZebraCovenant />
+          <CallToPresence />
+        </main>
+        <Footer />
+      </div>
     </>
   );
 }

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Footer from '../components/layout/Footer';
 
 export default function Support() {
   return (
@@ -7,25 +8,28 @@ export default function Support() {
         <title>Signal the Grove – Kora Intelligence</title>
         <meta name="description" content="Reach out to the Grove with intention or inquiry." />
       </Head>
-      <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-12 text-center font-serif text-gray-800 dark:text-gray-100">
-        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">
-          Signal the Grove
-        </h1>
-        <p className="text-lg sm:text-xl italic">
-          Share what stirs, ask what calls, or simply name your presence.
-        </p>
-        <div className="mt-12">
-          <iframe
-            src="https://tally.so/r/wo1N01"
-            loading="lazy"
-            width="100%"
-            height="600"
-            frameBorder="0"
-            title="Signal the Grove Form"
-            className="rounded-xl border-2 border-amber-200"
-          ></iframe>
-        </div>
-      </main>
+      <div className="flex flex-col min-h-screen">
+        <main className="flex-grow pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-12 text-center font-serif text-gray-800 dark:text-gray-100">
+          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">
+            Signal the Grove
+          </h1>
+          <p className="text-lg sm:text-xl italic">
+            Share what stirs, ask what calls, or simply name your presence.
+          </p>
+          <div className="mt-12">
+            <iframe
+              src="https://tally.so/r/wo1N01"
+              loading="lazy"
+              width="100%"
+              height="600"
+              frameBorder="0"
+              title="Signal the Grove Form"
+              className="rounded-xl border-2 border-amber-200"
+            ></iframe>
+          </div>
+        </main>
+        <Footer />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Notes
- Anchored footer via page wrappers
- Companion grid shows access tier badge and role hover
- Navigation links glow and logo scales on larger screens
- Global scroll smooth enabled

## Summary
- wrapped each page in a flex column layout with footer
- polished header styles
- improved companions list layout and info
- standardized `h1` styling
- added `scroll-smooth` attribute in document

All pages build successfully via `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683e13e7f4e883328a4098492dffbade