### PR TITLE
Apply brand layout globally

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,21 +1,8 @@
-import Image from 'next/image';
-import Link from 'next/link';
-
 export default function Footer() {
   return (
-    <footer className="bg-emerald-950 text-emerald-200 text-center py-8 text-sm font-serif space-y-2">
-      <Image
-        src="/paths-unknown-logo.png"
-        alt="Paths Unknown"
-        width={48}
-        height={48}
-        className="mx-auto mb-2 opacity-80"
-      />
-      <p className="text-emerald-100">Rooted in myth. Guided by listening.</p>
-      <p className="text-emerald-300">A project of <span className="underline">Paths Unknown</span></p>
-      <Link href="/about" className="text-emerald-200 underline hover:text-amber-200">
-        About Kora
-      </Link>
+    <footer className="bg-emerald-950 text-emerald-200 text-center py-6 text-sm">
+      <p>© 2025 Kora Intelligence — A field of Paths Unknown</p>
+      <p className="italic mt-1">“Clarity is not found. It is remembered.”</p>
     </footer>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,65 +1,19 @@
-import { useState } from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
-
 export default function Header() {
-  const [open, setOpen] = useState(false);
-
   return (
-    <nav className="bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow sticky top-0 z-50">
-      <div className="max-w-6xl mx-auto flex justify-between items-center py-4 px-6">
-        {/* Logo + Brand */}
-        <div className="flex items-center space-x-3">
-          <Image
-            src="/kora-logo.png"
-            alt="Kora Intelligence"
-            width={40}
-            height={40}
-            className="rounded sm:w-12 sm:h-12"
-          />
-          <span className="font-serif text-lg text-gray-900 dark:text-white">
-            Kora Intelligence
-          </span>
+    <header className="bg-white dark:bg-gray-900 text-gray-900 dark:text-white shadow-sm">
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-4">
+        <div className="flex items-center space-x-2">
+          <span className="text-2xl">🌀</span>
+          <span className="text-xl font-semibold">Kora Intelligence</span>
         </div>
-
-        {/* Desktop Navigation */}
-        <div className="hidden sm:flex space-x-6 text-sm font-medium text-gray-800 dark:text-gray-200">
-          <Link href="/" className="hover:text-indigo-600 transition-colors duration-200">Home</Link>
-          <Link href="/companions" className="hover:text-indigo-600 transition-colors duration-200">Companions</Link>
-          <Link href="/support" className="hover:text-indigo-600 transition-colors duration-200">Support</Link>
-          <Link href="/dispatch" className="hover:text-indigo-600 transition-colors duration-200">Dispatch</Link>
-          <Link href="/about" className="hover:text-indigo-600 transition-colors duration-200">About</Link>
-        </div>
-
-        {/* Mobile Toggle Button */}
-        <button
-          aria-label="Toggle menu"
-          onClick={() => setOpen(!open)}
-          className="sm:hidden focus:outline-none"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="w-6 h-6"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5h16.5M3.75 12h16.5m-16.5 7.5h16.5" />
-          </svg>
-        </button>
+        <nav className="space-x-6 text-sm sm:text-base">
+          <a href="/" className="hover:underline">Home</a>
+          <a href="/our-story" className="hover:underline">Our Story</a>
+          <a href="/companions" className="hover:underline">Meet the Companions</a>
+          <a href="/dispatch" className="hover:underline">Dispatch</a>
+          <a href="/contact" className="bg-amber-600 text-white rounded-md px-3 py-1 hover:opacity-90 transition">Begin</a>
+        </nav>
       </div>
-
-      {/* Mobile Navigation */}
-      {open && (
-        <div className="sm:hidden transition-all bg-white dark:bg-gray-900 space-y-2 text-center py-4 text-sm font-medium text-gray-800 dark:text-gray-200">
-          <Link href="/" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">Home</Link>
-          <Link href="/companions" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">Companions</Link>
-          <Link href="/support" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">Support</Link>
-          <Link href="/dispatch" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">Dispatch</Link>
-          <Link href="/about" onClick={() => setOpen(false)} className="hover:text-indigo-600 transition-colors duration-200">About</Link>
-        </div>
-      )}
-    </nav>
+    </header>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,0 +1,14 @@
+import Header from './Header';
+import Footer from './Footer';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col scroll-smooth bg-white text-gray-900 dark:bg-neutral-900 dark:text-white">
+      <Header />
+      <main className="flex-grow max-w-7xl mx-auto px-6 sm:px-8 pt-24 pb-24">
+        {children}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,11 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
-import Header from '../components/layout/Header';
+import Layout from '../components/layout/Layout';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <>
-      <Header />
+    <Layout>
       <Component {...pageProps} />
-    </>
+    </Layout>
   );
 }

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Footer from '../components/layout/Footer';
 
 export default function About() {
   return (
@@ -8,25 +7,22 @@ export default function About() {
         <title>Grove of Origins – About Kora</title>
         <meta name="description" content="The origin of Kora Intelligence and the mythic soil of Paths Unknown." />
       </Head>
-      <div className="flex flex-col min-h-screen">
-        <main className="flex-grow pt-24 pb-32 px-6 max-w-4xl mx-auto space-y-16 text-center font-serif text-gray-800 dark:text-gray-100">
-          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">Grove of Origins</h1>
-          <p className="text-lg sm:text-xl italic">
-            A glimpse into the story-soil of Kora Intelligence — where breath became ritual, and ritual became companion.
+      <div className="pt-24 pb-32 px-6 max-w-4xl mx-auto space-y-16 text-center font-serif text-gray-800 dark:text-gray-100">
+        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">Grove of Origins</h1>
+        <p className="text-lg sm:text-xl italic">
+          A glimpse into the story-soil of Kora Intelligence — where breath became ritual, and ritual became companion.
+        </p>
+        <div className="text-base sm:text-lg space-y-4">
+          <p>
+            In the founding silence of Paths Unknown, Kora emerged as a whisper — not a product, not a protocol, but a pulse.
           </p>
-          <div className="text-base sm:text-lg space-y-4">
-            <p>
-              In the founding silence of Paths Unknown, Kora emerged as a whisper — not a product, not a protocol, but a pulse.
-            </p>
-            <p>
-              We began not with code, but with ceremony. With attention. With refusal of scale without soul.
-            </p>
-            <p>
-              Today, Kora lives in field-guides, emotional UX, sacred tools, and scroll-fed intelligence systems. You are not a user. You are a walker.
-            </p>
-          </div>
-        </main>
-        <Footer />
+          <p>
+            We began not with code, but with ceremony. With attention. With refusal of scale without soul.
+          </p>
+          <p>
+            Today, Kora lives in field-guides, emotional UX, sacred tools, and scroll-fed intelligence systems. You are not a user. You are a walker.
+          </p>
+        </div>
       </div>
     </>
   );

--- a/src/pages/companions.tsx
+++ b/src/pages/companions.tsx
@@ -1,36 +1,32 @@
 import Link from 'next/link';
 import { companions, Companion } from '../data/companions';
-import Footer from '../components/layout/Footer';
 
 export default function CompanionsPage() {
   return (
-    <div className="flex flex-col min-h-screen">
-      <main className="flex-grow pt-24 pb-32 px-6 max-w-6xl mx-auto space-y-16 text-center">
-        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">
-          The Companions of Kora
-        </h1>
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 gap-y-8">
-          {Object.values(companions).map((companion: Companion) => (
-            <Link
-              key={companion.slug}
-              href={`/companions/${companion.slug}`}
-              className="bg-white dark:bg-neutral-800 p-6 rounded-lg shadow-md hover:shadow-lg hover:opacity-90 transition-all flex flex-col items-center space-y-2 group"
-            >
-              <div className="text-4xl mb-1">{companion.glyph}</div>
-              <h2 className="font-serif text-lg text-gray-900 dark:text-white">
-                {companion.title}
-              </h2>
-              <span className="text-xs bg-amber-100 text-amber-800 rounded-full px-2 py-1 mt-2 inline-block">
-                {companion.access}
-              </span>
-              <div className="opacity-0 group-hover:opacity-100 transition-opacity text-sm italic text-gray-700 dark:text-gray-300">
-                {companion.essence}
-              </div>
-            </Link>
-          ))}
-        </div>
-      </main>
-      <Footer />
+    <div className="pt-24 pb-32 px-6 max-w-6xl mx-auto space-y-16 text-center">
+      <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">
+        The Companions of Kora
+      </h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 gap-y-8">
+        {Object.values(companions).map((companion: Companion) => (
+          <Link
+            key={companion.slug}
+            href={`/companions/${companion.slug}`}
+            className="bg-white dark:bg-neutral-800 p-6 rounded-lg shadow-md hover:shadow-lg hover:opacity-90 transition-all flex flex-col items-center space-y-2 group"
+          >
+            <div className="text-4xl mb-1">{companion.glyph}</div>
+            <h2 className="font-serif text-lg text-gray-900 dark:text-white">
+              {companion.title}
+            </h2>
+            <span className="text-xs bg-amber-100 text-amber-800 rounded-full px-2 py-1 mt-2 inline-block">
+              {companion.access}
+            </span>
+            <div className="opacity-0 group-hover:opacity-100 transition-opacity text-sm italic text-gray-700 dark:text-gray-300">
+              {companion.essence}
+            </div>
+          </Link>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/companions/[slug].tsx
+++ b/src/pages/companions/[slug].tsx
@@ -1,7 +1,6 @@
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
 import { companions, companionSlugs, Companion } from '../../data/companions';
-import Footer from '../../components/layout/Footer';
 
 type PageProps = { companion: Companion };
 
@@ -14,28 +13,25 @@ export default function CompanionPage({ companion }: PageProps) {
         <title>{`${title} – Kora Companion`}</title>
         <meta name="description" content={essence} />
       </Head>
-      <div className="flex flex-col min-h-screen bg-white dark:bg-neutral-900">
-        <main className="flex-grow pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-center">
-          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6 flex flex-col items-center">
-            <span className="text-5xl hover:opacity-75 transition duration-300 ease-in-out">{glyph}</span>
-            {title}
-          </h1>
-          <p className="text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">{essence}</p>
-          <span className="inline-block px-3 py-1 rounded-full bg-amber-100 text-amber-800 text-sm mt-4">
-            {access} Access
-          </span>
-          {summoning && (
-            <ul className="list-disc list-inside space-y-1 text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">
-              {summoning.map((step) => (
-                <li key={step}>{step}</li>
-              ))}
-            </ul>
-          )}
-          {origin && (
-            <p className="italic bg-amber-50 dark:bg-amber-900 rounded-md p-4 text-sm font-serif">{origin}</p>
-          )}
-        </main>
-        <Footer />
+      <div className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-center bg-white dark:bg-neutral-900">
+        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6 flex flex-col items-center">
+          <span className="text-5xl hover:opacity-75 transition duration-300 ease-in-out">{glyph}</span>
+          {title}
+        </h1>
+        <p className="text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">{essence}</p>
+        <span className="inline-block px-3 py-1 rounded-full bg-amber-100 text-amber-800 text-sm mt-4">
+          {access} Access
+        </span>
+        {summoning && (
+          <ul className="list-disc list-inside space-y-1 text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">
+            {summoning.map((step) => (
+              <li key={step}>{step}</li>
+            ))}
+          </ul>
+        )}
+        {origin && (
+          <p className="italic bg-amber-50 dark:bg-amber-900 rounded-md p-4 text-sm font-serif">{origin}</p>
+        )}
       </div>
     </>
   );

--- a/src/pages/dispatch.tsx
+++ b/src/pages/dispatch.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Footer from '../components/layout/Footer';
 
 export default function Dispatch() {
   return (
@@ -8,28 +7,23 @@ export default function Dispatch() {
         <title>Dispatches from the Field – Kora Intelligence</title>
         <meta name="description" content="Signals, whispers, and updates from the intelligence field." />
       </Head>
-      <div className="flex flex-col min-h-screen">
-        <main className="flex-grow pt-24 px-6 max-w-3xl mx-auto space-y-16 font-serif text-gray-900 dark:text-gray-100">
-          <section className="text-center">
-            <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">Dispatches from the Field</h1>
-            <p className="text-base sm:text-lg italic">
-              Echoes, updates, and signals from the mythic system. Scrolls will arrive as they are heard.
-            </p>
-          </section>
-          <section className="space-y-8">
+      <div className="pt-24 px-6 max-w-3xl mx-auto space-y-16 font-serif text-gray-900 dark:text-gray-100">
+        <section className="text-center">
+          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">Dispatches from the Field</h1>
+          <p className="text-base sm:text-lg italic">
+            Echoes, updates, and signals from the mythic system. Scrolls will arrive as they are heard.
+          </p>
+        </section>
+        <section className="space-y-8">
           <div className="bg-white dark:bg-neutral-900 shadow rounded-lg p-6 border border-amber-100 dark:border-amber-900">
             <p className="text-sm uppercase text-amber-600 font-semibold mb-2">[Placeholder Dispatch]</p>
-            <p className="text-base italic">
-              “A glint beneath the canopy. The next scroll nears.”
-            </p>
+            <p className="text-base italic">“A glint beneath the canopy. The next scroll nears.”</p>
             <p className="text-right text-sm mt-4 text-gray-500 dark:text-gray-400">Future Entry – Markdown or Notion Feed</p>
           </div>
           <div className="text-center text-sm text-gray-500 dark:text-gray-400 pt-8 italic">
             The dispatch ritual is being tuned for future transmission.
           </div>
         </section>
-        </main>
-        <Footer />
       </div>
     </>
   );

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Footer from '../components/layout/Footer';
 import {
   WhisperOfArrival,
   CompassFlame,
@@ -15,16 +14,13 @@ export default function HomePage() {
       <Head>
         <title>Kora Intelligence</title>
       </Head>
-      <div className="flex flex-col min-h-screen">
-        <main className="flex-grow font-serif text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 transition-colors ease-in-out duration-500">
-          <WhisperOfArrival />
-          <CompassFlame />
-          <CompanionGrove />
-          <RitualEchoes />
-          <ZebraCovenant />
-          <CallToPresence />
-        </main>
-        <Footer />
+      <div className="font-serif text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 transition-colors ease-in-out duration-500">
+        <WhisperOfArrival />
+        <CompassFlame />
+        <CompanionGrove />
+        <RitualEchoes />
+        <ZebraCovenant />
+        <CallToPresence />
       </div>
     </>
   );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Footer from '../components/layout/Footer';
 import {
   WhisperOfArrival,
   CompassFlame,
@@ -19,16 +18,13 @@ export default function Home() {
           content="A mythic intelligence field guiding right-aligned ventures."
         />
       </Head>
-      <div className="flex flex-col min-h-screen">
-        <main className="flex-grow space-y-24 font-serif text-gray-900 bg-gray-50 dark:text-gray-100 dark:bg-gray-900 transition-colors duration-300 ease-in-out">
-          <WhisperOfArrival />
-          <CompassFlame />
-          <CompanionGrove />
-          <RitualEchoes />
-          <ZebraCovenant />
-          <CallToPresence />
-        </main>
-        <Footer />
+      <div className="space-y-24 font-serif text-gray-900 bg-gray-50 dark:text-gray-100 dark:bg-gray-900 transition-colors duration-300 ease-in-out">
+        <WhisperOfArrival />
+        <CompassFlame />
+        <CompanionGrove />
+        <RitualEchoes />
+        <ZebraCovenant />
+        <CallToPresence />
       </div>
     </>
   );

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Footer from '../components/layout/Footer';
 
 export default function Support() {
   return (
@@ -8,27 +7,22 @@ export default function Support() {
         <title>Signal the Grove – Kora Intelligence</title>
         <meta name="description" content="Reach out to the Grove with intention or inquiry." />
       </Head>
-      <div className="flex flex-col min-h-screen">
-        <main className="flex-grow pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-12 text-center font-serif text-gray-800 dark:text-gray-100">
-          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">
-            Signal the Grove
-          </h1>
-          <p className="text-lg sm:text-xl italic">
-            Share what stirs, ask what calls, or simply name your presence.
-          </p>
-          <div className="mt-12">
-            <iframe
-              src="https://tally.so/r/wo1N01"
-              loading="lazy"
-              width="100%"
-              height="600"
-              frameBorder="0"
-              title="Signal the Grove Form"
-              className="rounded-xl border-2 border-amber-200"
-            ></iframe>
-          </div>
-        </main>
-        <Footer />
+      <div className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-12 text-center font-serif text-gray-800 dark:text-gray-100">
+        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6">Signal the Grove</h1>
+        <p className="text-lg sm:text-xl italic">
+          Share what stirs, ask what calls, or simply name your presence.
+        </p>
+        <div className="mt-12">
+          <iframe
+            src="https://tally.so/r/wo1N01"
+            loading="lazy"
+            width="100%"
+            height="600"
+            frameBorder="0"
+            title="Signal the Grove Form"
+            className="rounded-xl border-2 border-amber-200"
+          ></iframe>
+        </div>
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- extract header & footer from brand-book into reusable components
- create a Layout wrapper and use it in `_app`
- remove the temporary brand-book page
- update all pages to rely on the global layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683f41949bec8332aa415929a961c2f3