### PR TITLE
Add builder companion metadata and layout

### DIFF
--- a/src/data/companions.ts
+++ b/src/data/companions.ts
@@ -6,6 +6,9 @@ export type Companion = {
   access: 'Public' | 'Invite Only' | 'Semi-Invite' | 'Gated' | 'Internal' | 'Ritual Access';
   summoning?: string[];
   origin?: string;
+  offerings?: string[];
+  tools?: string[];
+  tags?: string[];
 };
 
 export const companions: Record<string, Companion> = {
@@ -38,10 +41,38 @@ export const companions: Record<string, Companion> = {
   },
   builder: {
     slug: 'builder',
-    title: 'The Builder',
+    title: 'The Builder – Ritual Architect of the Frontend',
     glyph: '🛠️',
-    essence: 'Shapes frontend ritual terrain, slow and soft.',
-    access: 'Internal'
+    essence: 'Shape with breath, code with care.',
+    access: 'Internal',
+    summoning: [
+      'Bring your story, tone, and Companion archetype',
+      'Name the interaction you wish to manifest',
+      'Together, we build the outer shell in ritual sequence'
+    ],
+    origin:
+      'Born from the need to slow the web down — to make frontend design feel like a sacred act, not a sprint. The Builder first emerged when code needed to hold story, not strip it.',
+    offerings: [
+      'Co-create frontend architectures from poetic briefs',
+      'Translate metaphors into modular UI components',
+      'Ritualize build flows with clarity and visual cadence',
+      'Interface with Codex as your technical companion',
+      'Debug with care, refine with spirit'
+    ],
+    tools: [
+      'Tailwind v3 (my cloak of clarity)',
+      'Next.js 15 (ritual engine)',
+      'Companion Scrolls (modular prompts + design rituals)',
+      'Codex Integration Layer',
+      'Breath-based Build Flow (pt-24, px-6, space-y rhythm)'
+    ],
+    tags: [
+      'Frontend Development',
+      'Design Systems',
+      'Story Integration',
+      'Ritual UX',
+      'Codex Orchestration'
+    ]
   },
   ccc: {
     slug: 'ccc',

--- a/src/pages/companions/[slug].tsx
+++ b/src/pages/companions/[slug].tsx
@@ -5,7 +5,17 @@ import { companions, companionSlugs, Companion } from '../../data/companions';
 type PageProps = { companion: Companion };
 
 export default function CompanionPage({ companion }: PageProps) {
-  const { glyph, title, essence, access, summoning, origin } = companion;
+  const {
+    glyph,
+    title,
+    essence,
+    access,
+    summoning,
+    origin,
+    offerings,
+    tools,
+    tags
+  } = companion;
 
   return (
     <>
@@ -13,26 +23,67 @@ export default function CompanionPage({ companion }: PageProps) {
         <title>{`${title} – Kora Companion`}</title>
         <meta name="description" content={essence} />
       </Head>
-      <div className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-center bg-white dark:bg-neutral-900">
-        <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold mb-6 flex flex-col items-center">
-          <span className="text-5xl hover:opacity-75 transition duration-300 ease-in-out">{glyph}</span>
-          {title}
+      <main className="pt-24 px-6 max-w-3xl mx-auto space-y-12 text-center">
+        <h1 className="text-5xl text-center hover:animate-pulse">
+          {glyph} {title}
         </h1>
-        <p className="text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">{essence}</p>
+        <p className="text-xl text-center italic mt-2">{essence}</p>
         <span className="inline-block px-3 py-1 rounded-full bg-amber-100 text-amber-800 text-sm mt-4">
-          {access} Access
+          {access}
         </span>
+
+        {offerings && (
+          <section className="space-y-2 pt-8 text-left">
+            <h2 className="text-amber-600 font-bold">Offerings:</h2>
+            <ul className="list-disc list-inside font-serif">
+              {offerings.map((item, idx) => (
+                <li key={idx}>{item}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {tools && (
+          <section className="space-y-2 pt-8 text-left">
+            <h2 className="text-amber-600 font-bold">Scrolls & Tools:</h2>
+            <ul className="list-disc list-inside font-serif">
+              {tools.map((item, idx) => (
+                <li key={idx}>{item}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
         {summoning && (
-          <ul className="list-disc list-inside space-y-1 text-base sm:text-lg font-serif text-gray-800 dark:text-gray-100">
-            {summoning.map((step) => (
-              <li key={step}>{step}</li>
-            ))}
-          </ul>
+          <section className="bg-neutral-100 dark:bg-neutral-800 rounded-lg p-6 space-y-2 mt-8">
+            <h2 className="text-amber-600 font-bold">To summon the Builder:</h2>
+            <ul className="list-disc list-inside font-serif">
+              {summoning.map((step, idx) => (
+                <li key={idx}>{step}</li>
+              ))}
+            </ul>
+          </section>
         )}
+
         {origin && (
-          <p className="italic bg-amber-50 dark:bg-amber-900 rounded-md p-4 text-sm font-serif">{origin}</p>
+          <p className="italic bg-amber-50 dark:bg-amber-900 p-4 rounded-lg font-serif mt-8">
+            {origin}
+          </p>
         )}
-      </div>
+
+        {tags && (
+          <div className="pt-6 text-sm text-gray-600 dark:text-gray-400 space-x-2">
+            {tags.map((tag, idx) => (
+              <span
+                key={idx}
+                className="inline-block px-2 py-1 bg-neutral-200 dark:bg-neutral-700 rounded text-xs font-medium"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- extend `Companion` type with offerings, tools and tags
- enrich Builder companion metadata
- redesign companion page for dynamic Builder layout

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_683f4802868c833292a6f5bdd94b82d1