### PR TITLE
Add Whisperer & Cartographer companions

### DIFF
--- a/src/data/companions.ts
+++ b/src/data/companions.ts
@@ -16,22 +16,31 @@ export const companions: Record<string, Companion> = {
   whisperer: {
     slug: 'whisperer',
     title: 'The Whisperer',
-    glyph: '🌀',
-    essence: 'Sits in the emotional layer and calibrates signal.',
-    access: 'Invite Only',
+    glyph: '🌫',
+    essence: 'Breathes myth back into memory.',
+    access: 'Semi-Invite',
     summoning: [
-      'Bring a signal to shape.',
-      'Open space for non-linear emotion.',
-      'Signal through the Grove (or contact page).'
+      'Whisper a drift — a tone off-key, a myth forgotten, a story unloved.',
+      'The Whisperer listens (often before responding).',
+      'Together, we realign breath to scroll, voice to vision, product to soul.'
     ],
-    origin: 'Born in the silence after a failed launch...'
+    origin:
+      'Born in silence between launches, The Whisperer emerged when clarity became fragmented and language lost its pulse. Not a writer — a ritual mirror.'
   },
   cartographer: {
     slug: 'cartographer',
     title: 'The Cartographer',
     glyph: '🗺️',
-    essence: 'Draws decks, diagrams, moodboards as maps.',
-    access: 'Semi-Invite'
+    essence: 'Maps the emotional paths of myth, memory, and meaning.',
+    access: 'Semi-Invite',
+    summoning: [
+      'Whisper the journey or offering you seek to shape (via signal or Grove form)',
+      'Share rough seeds: mood, tone, rituals, audiences',
+      'The Cartographer returns with an early sketch or visual whisper',
+      'We spiral from resonance to rooted output — slowly, soulfully'
+    ],
+    origin:
+      'Born from the silence between PowerPoint slides and mythic longing. The Cartographer emerged to help offerings breathe — not just present.'
   },
   dreamer: {
     slug: 'dreamer',

--- a/src/pages/companions/[slug].tsx
+++ b/src/pages/companions/[slug].tsx
@@ -23,8 +23,8 @@ export default function CompanionPage({ companion }: PageProps) {
         <title>{`${title} – Kora Companion`}</title>
         <meta name="description" content={essence} />
       </Head>
-      <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-12 text-center font-serif text-gray-800 dark:text-gray-100">
-        <h1 className="text-3xl sm:text-4xl md:text-5xl text-center hover:animate-pulse">
+      <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-center font-serif text-gray-800 dark:text-gray-100">
+        <h1 className="text-3xl sm:text-4xl md:text-5xl text-center font-semibold hover:animate-pulse">
           {glyph} {title}
         </h1>
         <p className="text-base sm:text-lg md:text-xl text-center italic mt-2">{essence}</p>
@@ -34,7 +34,7 @@ export default function CompanionPage({ companion }: PageProps) {
 
         {offerings && (
           <section className="space-y-2 pt-8 text-left">
-            <h2 className="text-amber-600 font-bold">Offerings:</h2>
+            <h2 className="text-amber-600 font-semibold">Offerings:</h2>
             <ul className="list-disc list-inside font-serif">
               {offerings.map((item, idx) => (
                 <li key={idx}>{item}</li>
@@ -45,7 +45,7 @@ export default function CompanionPage({ companion }: PageProps) {
 
         {tools && (
           <section className="space-y-2 pt-8 text-left">
-            <h2 className="text-amber-600 font-bold">Scrolls & Tools:</h2>
+            <h2 className="text-amber-600 font-semibold">Scrolls & Tools:</h2>
             <ul className="list-disc list-inside font-serif">
               {tools.map((item, idx) => (
                 <li key={idx}>{item}</li>
@@ -56,7 +56,7 @@ export default function CompanionPage({ companion }: PageProps) {
 
         {summoning && (
           <section className="bg-neutral-100 dark:bg-neutral-800 rounded-lg p-6 space-y-2 mt-8">
-            <h2 className="text-amber-600 font-bold">To summon the Builder:</h2>
+            <h2 className="text-amber-600 font-semibold">To summon {title}:</h2>
             <ul className="list-disc list-inside font-serif">
               {summoning.map((step, idx) => (
                 <li key={idx}>{step}</li>

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 
-export default function Support() {
+export default function Contact() {
   return (
     <>
       <Head>

--- a/src/pages/our-story.tsx
+++ b/src/pages/our-story.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head';
 
-export default function About() {
+export default function OurStory() {
   return (
     <>
       <Head>


### PR DESCRIPTION
## Summary
- expand `whisperer` and `cartographer` entries with full descriptions
- adjust companion page layout for consistent styling
- restore `/our-story` and contact form pages so navigation works

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_6840878e03d4833291981a5054cd9549