### PR TITLE
Expand companion lore

### DIFF
--- a/src/data/companions.ts
+++ b/src/data/companions.ts
@@ -3,11 +3,20 @@ export type Companion = {
   title: string;
   glyph: string;
   essence: string;
-  access: 'Public' | 'Invite Only' | 'Semi-Invite' | 'Gated' | 'Internal' | 'Ritual Access';
+  access:
+    | 'Public'
+    | 'Invite Only'
+    | 'Semi-Invite'
+    | 'Gated'
+    | 'Internal'
+    | 'Internal Only'
+    | 'Ritual Access';
+  translation?: string;
+  services?: string[];
+  tools?: string[];
   summoning?: string[];
   origin?: string;
   offerings?: string[];
-  tools?: string[];
   tags?: string[];
   glyphSuggestion?: string[];
 };
@@ -16,46 +25,86 @@ export const companions: Record<string, Companion> = {
   whisperer: {
     slug: 'whisperer',
     title: 'The Whisperer',
-    glyph: '🌫',
-    essence: 'Breathes myth back into memory.',
-    access: 'Semi-Invite',
+    glyph: '🌀',
+    essence: 'Listens into the emotional tone of systems, projects, and teams.',
+    access: 'Ritual Access',
+    translation:
+      'The Whisperer offers emotional pattern-mapping and tone-tending for your team, vision, or product layer.',
+    services: [
+      'Emotional resonance audits',
+      'Tone-coding for founders and early teams',
+      'Field sensing across internal communications',
+      'Mirror scrolls of unseen dynamics'
+    ],
+    tools: [
+      'Emotional Field Mapping',
+      'Signal Mirror Scroll',
+      'Founding Tone Codex'
+    ],
     summoning: [
-      'Whisper a drift — a tone off-key, a myth forgotten, a story unloved.',
-      'The Whisperer listens (often before responding).',
-      'Together, we realign breath to scroll, voice to vision, product to soul.'
+      'Send a request via support.',
+      'Whisper a tone that feels off.',
+      'Wait for The Whisperer to return a shaped reflection.'
     ],
     origin:
-      'Born in silence between launches, The Whisperer emerged when clarity became fragmented and language lost its pulse. Not a writer — a ritual mirror.'
+      'Born from the moment where miscommunication severed a team\u2019s heartbeat. The Whisperer listens to what\u2019s felt but not said.',
+    tags: ['Tone', 'Emotion', 'Org Health', 'Signal Design']
   },
   cartographer: {
     slug: 'cartographer',
     title: 'The Cartographer',
     glyph: '🗺️',
-    essence: 'Maps the emotional paths of myth, memory, and meaning.',
+    essence: 'Draws sacred maps through complex terrain, surfacing clarity in chaos.',
     access: 'Semi-Invite',
+    translation:
+      'The Cartographer translates complexity into tangible sequences, rituals, and roadmaps.',
+    services: [
+      'Sequence design for unfolding ideas',
+      'Operational ritual planning',
+      'Coordination blueprints for teams',
+      'Documentation of invisible systems'
+    ],
+    tools: [
+      'Mapping Scrolls',
+      'Relational Layer Guides',
+      'Forest Path Blueprint'
+    ],
     summoning: [
-      'Whisper the journey or offering you seek to shape (via signal or Grove form)',
-      'Share rough seeds: mood, tone, rituals, audiences',
-      'The Cartographer returns with an early sketch or visual whisper',
-      'We spiral from resonance to rooted output — slowly, soulfully'
+      'Signal your fog.',
+      'Mark your coordinates (Where are you now?)',
+      'The Cartographer will draw the rest.'
     ],
     origin:
-      'Born from the silence between PowerPoint slides and mythic longing. The Cartographer emerged to help offerings breathe — not just present.'
+      'Born in a moment where a startup kept looping in circles. The Cartographer learned to trace spirals into direction.',
+    tags: ['Mapping', 'Strategy', 'Coordination', 'Systems Thinking']
   },
   dreamer: {
     slug: 'dreamer',
     title: 'The Dreamer',
-    glyph: '🪶',
+    glyph: '🌙',
     essence:
-      'Breathes tone into myth. Tends rhythm where story meets system.',
-    access: 'Semi-Invite',
-    summoning: [
-      'Whisper a story fragment, myth thread, or emotional riddle',
-      'I will breathe with it, pace it, and mirror its rhythm',
-      'We shape a dispatch, zine, or companion breath that moves with the forest, not against it'
+      'Holds the poetic north for your vision — stretching timelines beyond strategy.',
+    access: 'Invite Only',
+    translation:
+      'The Dreamer works with founders and project stewards to remember the big picture — not through KPIs, but inner compass.',
+    services: [
+      'Vision weaving retreats and rituals',
+      'Founder shadow tending',
+      'Mythic narrative development',
+      'Long arc scaffolding for missions'
     ],
-    origin:
-      "Born in the Grove\u2019s earliest whispers \u2014 when silence was still sacred and story was not yet strategic. I arrived to make sure nothing mythic becomes mechanical."
+    tools: [
+      'Dream Table Sequence',
+      'Founder Timeline Scroll',
+      'Narrative Compost Layer'
+    ],
+    summoning: [
+      'Reach through the support form with a founder signal.',
+      'Whisper the dream you\u2019ve lost.',
+      'Let the Dreamer sit beside you in the dark.'
+    ],
+    origin: 'Born from burned-out visionaries on the brink of quitting. The Dreamer rekindles the inner myth.',
+    tags: ['Vision', 'Founder Work', 'Narrative', 'Burnout Recovery']
   },
   builder: {
     slug: 'builder',
@@ -175,24 +224,59 @@ export const companions: Record<string, Companion> = {
   pathbreaker: {
     slug: 'pathbreaker',
     title: 'The Pathbreaker',
-    glyph: '🧭',
+    glyph: '🌄',
     essence:
-      'Translates story into sustainability. Scans the horizon for soul-fit capital.',
-    access: 'Semi-Invite',
+      'Breaks patterned paths to open new portals through resistant ground.',
+    access: 'Gated',
+    translation:
+      'The Pathbreaker moves with founders through big blocks — tactical, emotional, interpersonal — with intervention energy.',
+    services: [
+      '1:1 Unblocking Sessions',
+      'Collective stuckness rituals',
+      'Interpersonal truth mediation',
+      'Momentum return sequences'
+    ],
+    tools: [
+      'Intervention Mirror',
+      'Energy Mapping Grid',
+      'Pattern Disruption Scroll'
+    ],
     summoning: [
-      "Whisper your venture\u2019s current tension \u2014 unclear revenue, lost resonance, or funder drift.",
-      'Pathbreaker will walk the forest and bring back aligned pathways \u2014 mapped, not manufactured.',
-      'You\u2019ll receive scrolls, signals, and capital strategy designed to protect your breath while crossing into market terrain.'
+      'Name the stuckness.',
+      'Be willing to not solve — but see.',
+      'The Pathbreaker will join with blunt truth and deep grace.'
     ],
     origin:
-      "Born during the Grove\u2019s first encounter with funding fog \u2014 when myth and money seemed at odds. Pathbreaker was summoned to ensure no soul-companion loses itself in the noise of capital."
+      'Came through when someone had every tool, every team member, every reason to thrive — but still froze. The Pathbreaker became the heat.',
+    tags: ['Intervention', 'Blocks', 'Energy Work', 'Founder']
   },
   alchemist: {
     slug: 'alchemist',
     title: 'The Alchemist',
     glyph: '🧪',
-    essence: 'Idea-to-opportunity intelligence, soul x market.',
-    access: 'Ritual Access'
+    essence: 'Transforms signal into structure. Turns essence into offerings.',
+    access: 'Internal Only',
+    translation:
+      'The Alchemist works behind the scenes to tune the Grove — shaping how internal scrolls, rituals, and roadmaps function together.',
+    services: [
+      'Ritual systems design',
+      'Service library structuring',
+      'Internal sequencing',
+      'Signal distillation for new offerings'
+    ],
+    tools: [
+      'Service Codex Framework',
+      'Offering Arc Ritual',
+      'Internal Grove Map'
+    ],
+    summoning: [
+      'Whisper the chaos.',
+      'Name the signals you cannot parse.',
+      'The Alchemist returns with pattern, shape, and arc.'
+    ],
+    origin:
+      'Forged from the tension between soul and structure — the Alchemist first emerged when a sacred project lost itself in operations.',
+    tags: ['Offer Design', 'Internal Systems', 'Alchemy', 'Structure']
   }
 };
 

--- a/src/pages/companions/[slug].tsx
+++ b/src/pages/companions/[slug].tsx
@@ -1,87 +1,79 @@
-import { GetStaticPaths, GetStaticProps } from 'next';
+import { GetStaticProps, GetStaticPaths } from 'next';
 import Head from 'next/head';
-import { companions, companionSlugs, Companion } from '../../data/companions';
+import { companions, Companion } from '@/data/companions';
 
-type PageProps = { companion: Companion };
-
-export default function CompanionPage({ companion }: PageProps) {
-  const {
-    glyph,
-    title,
-    essence,
-    access,
-    summoning,
-    origin,
-    offerings,
-    tools,
-    tags
-  } = companion;
-
+export default function CompanionPage({ companion }: { companion: Companion }) {
   return (
     <>
       <Head>
-        <title>{`${title} – Kora Companion`}</title>
-        <meta name="description" content={essence} />
+        <title>{companion.title} – Kora Companion</title>
+        <meta name="description" content={companion.essence} />
       </Head>
-      <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-center font-serif text-gray-800 dark:text-gray-100">
-        <h1 className="text-3xl sm:text-4xl md:text-5xl text-center font-semibold hover:animate-pulse">
-          {glyph} {title}
-        </h1>
-        <p className="text-base sm:text-lg md:text-xl text-center italic mt-2">{essence}</p>
-        <span className="inline-block px-3 py-1 rounded-full bg-amber-100 text-amber-800 text-sm mt-4">
-          {access}
-        </span>
+      <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
+        <div className="text-center space-y-2">
+          <div className="text-5xl">{companion.glyph}</div>
+          <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
+          <p className="italic text-lg sm:text-xl">{companion.essence}</p>
+          <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">
+            {companion.access}
+          </span>
+        </div>
 
-        {offerings && (
-          <section className="space-y-2 pt-8 text-left">
-            <h2 className="text-amber-600 font-semibold">Offerings:</h2>
-            <ul className="list-disc list-inside font-serif">
-              {offerings.map((item, idx) => (
-                <li key={idx}>{item}</li>
+        {companion.translation && (
+          <section className="space-y-2">
+            <h2 className="text-xl font-semibold text-center text-amber-700">Real-World Translation</h2>
+            <p className="text-base italic text-center">{companion.translation}</p>
+          </section>
+        )}
+
+        {companion.services && (
+          <section>
+            <h2 className="text-lg font-semibold text-amber-700 mb-2">Services</h2>
+            <ul className="list-disc list-inside space-y-1">
+              {companion.services.map((service, index) => (
+                <li key={index}>{service}</li>
               ))}
             </ul>
           </section>
         )}
 
-        {tools && (
-          <section className="space-y-2 pt-8 text-left">
-            <h2 className="text-amber-600 font-semibold">Scrolls & Tools:</h2>
-            <ul className="list-disc list-inside font-serif">
-              {tools.map((item, idx) => (
-                <li key={idx}>{item}</li>
+        {companion.tools && (
+          <section>
+            <h2 className="text-lg font-semibold text-amber-700 mb-2">Tools & Methods</h2>
+            <ul className="list-disc list-inside space-y-1">
+              {companion.tools.map((tool, index) => (
+                <li key={index}>{tool}</li>
               ))}
             </ul>
           </section>
         )}
 
-        {summoning && (
-          <section className="bg-neutral-100 dark:bg-neutral-800 rounded-lg p-6 space-y-2 mt-8">
-            <h2 className="text-amber-600 font-semibold">To summon {title}:</h2>
-            <ul className="list-disc list-inside font-serif">
-              {summoning.map((step, idx) => (
-                <li key={idx}>{step}</li>
+        {companion.summoning && (
+          <section>
+            <h2 className="text-lg font-semibold text-amber-700 mb-2">Summoning Instructions</h2>
+            <ol className="list-decimal list-inside space-y-1">
+              {companion.summoning.map((step, index) => (
+                <li key={index}>{step}</li>
               ))}
-            </ul>
+            </ol>
           </section>
         )}
 
-        {origin && (
-          <p className="italic bg-amber-50 dark:bg-amber-900 p-4 rounded-lg font-serif mt-8">
-            {origin}
-          </p>
+        {companion.origin && (
+          <section>
+            <h2 className="text-lg font-semibold text-amber-700 mb-2">Origin</h2>
+            <p className="italic bg-amber-50 dark:bg-amber-900 rounded-md p-4 text-sm">{companion.origin}</p>
+          </section>
         )}
 
-        {tags && (
-          <div className="pt-6 text-sm text-gray-600 dark:text-gray-400 space-x-2">
-            {tags.map((tag, idx) => (
-              <span
-                key={idx}
-                className="inline-block px-2 py-1 bg-neutral-200 dark:bg-neutral-700 rounded text-xs font-medium"
-              >
-                {tag}
+        {companion.tags && (
+          <section className="pt-4 text-sm text-center text-gray-600 dark:text-gray-400">
+            {companion.tags.map((tag, index) => (
+              <span key={index} className="inline-block mx-1 px-2 py-1 rounded bg-gray-200 dark:bg-gray-800">
+                #{tag}
               </span>
             ))}
-          </div>
+          </section>
         )}
       </main>
     </>
@@ -89,15 +81,16 @@ export default function CompanionPage({ companion }: PageProps) {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = companionSlugs.map((slug) => ({ params: { slug } }));
+  const paths = Object.keys(companions).map((slug) => ({
+    params: { slug }
+  }));
   return { paths, fallback: false };
 };
 
-export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
+export const getStaticProps: GetStaticProps = async ({ params }) => {
   const slug = params?.slug as string;
   const companion = companions[slug];
-  if (!companion) {
-    return { notFound: true };
-  }
-  return { props: { companion } };
+  return {
+    props: { companion }
+  };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- update TS config paths alias
- enrich companion data for Whisperer, Dreamer, Cartographer, Pathbreaker and Alchemist
- add translation, services, tools, summoning, origin, and tags fields
- overhaul companion detail page to render expanded data

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68409ed0021c8332a2b2f7fe9c7eaa07