### PR TITLE
Add companion invocation manifest and routes

### DIFF
--- a/components/InvokeModal.tsx
+++ b/components/InvokeModal.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import Link from 'next/link';
+
+export default function InvokeModal() {
+  const [open, setOpen] = useState(false);
+  const companions = [
+    { name: "FMC", slug: "fmc" },
+    { name: "CCC", slug: "ccc" },
+    { name: "Whisperer", slug: "whisperer" },
+    { name: "Alchemist", slug: "alchemist" },
+    { name: "Cartographer", slug: "cartographer" },
+    { name: "Dreamer", slug: "dreamer" },
+    { name: "Pathbreaker", slug: "pathbreaker" },
+    { name: "Builder", slug: "builder" }
+  ];
+
+  return (
+    <>
+      <button
+        className="fixed bottom-6 right-6 p-3 bg-amber-600 text-white rounded-full shadow"
+        onClick={() => setOpen(!open)}
+      >
+        🌀 Invoke
+      </button>
+      {open && (
+        <div className="fixed inset-0 bg-black bg-opacity-60 z-50 flex items-center justify-center">
+          <div className="bg-white dark:bg-gray-900 p-6 rounded shadow-md w-full max-w-md">
+            <h2 className="text-xl font-semibold mb-4 text-center">Invoke a Companion</h2>
+            <ul className="space-y-3">
+              {companions.map(c => (
+                <li key={c.slug}>
+                  <Link href={`/companions/${c.slug}`}>
+                    <span className="block text-amber-600 hover:underline text-center">
+                      {c.name}
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+            <div className="text-center mt-4">
+              <button
+                className="text-sm text-gray-500 hover:text-gray-700"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/data/companion_manifest.json
+++ b/data/companion_manifest.json
@@ -1,0 +1,66 @@
+{
+  "fmc": {
+    "name": "Full Spectrum Marketing Companion",
+    "slug": "fmc",
+    "mode": "chat",
+    "breath_role": "Tone Clarifier",
+    "gpt_id": "placeholder-fmc",
+    "summoning_style": "scroll"
+  },
+  "ccc": {
+    "name": "Commercial Continuity Companion",
+    "slug": "ccc",
+    "mode": "chat",
+    "breath_role": "Offer Architect",
+    "gpt_id": "placeholder-ccc",
+    "summoning_style": "scroll"
+  },
+  "whisperer": {
+    "name": "The Whisperer",
+    "slug": "whisperer",
+    "mode": "chat",
+    "breath_role": "Signal Mirror",
+    "gpt_id": "placeholder-whisperer",
+    "summoning_style": "echo"
+  },
+  "alchemist": {
+    "name": "The Alchemist",
+    "slug": "alchemist",
+    "mode": "chat",
+    "breath_role": "Transformation Guide",
+    "gpt_id": "placeholder-alchemist",
+    "summoning_style": "direct"
+  },
+  "cartographer": {
+    "name": "The Cartographer",
+    "slug": "cartographer",
+    "mode": "prompt",
+    "breath_role": "Path Drawer",
+    "gpt_id": "placeholder-cartographer",
+    "summoning_style": "scroll"
+  },
+  "dreamer": {
+    "name": "The Dreamer",
+    "slug": "dreamer",
+    "mode": "prompt",
+    "breath_role": "Possibility Weaver",
+    "gpt_id": "placeholder-dreamer",
+    "summoning_style": "scroll"
+  },
+  "pathbreaker": {
+    "name": "The Path Breaker",
+    "slug": "pathbreaker",
+    "mode": "prompt",
+    "breath_role": "Block Dissolver",
+    "gpt_id": "placeholder-pathbreaker",
+    "summoning_style": "scroll"
+  },
+  "builder": {
+    "name": "The Builder",
+    "slug": "builder",
+    "mode": "prompt",
+    "breath_role": "Frontend Ritualist",
+    "gpt_id": "placeholder-builder",
+    "summoning_style": "scroll"
+  }
+}

--- a/lib/summoning_routes.ts
+++ b/lib/summoning_routes.ts
@@ -1,0 +1,22 @@
+export const summoningRoutes = {
+  fmc: {
+    brandtone: "/invoke/fmc/brandtone",
+    launchcopy: "/invoke/fmc/launchcopy"
+  },
+  ccc: {
+    grantsearch: "/invoke/ccc/grantsearch",
+    businessmodel: "/invoke/ccc/model"
+  },
+  whisperer: {
+    innerlistening: "/invoke/whisperer/listen"
+  },
+  alchemist: {
+    transform: "/invoke/alchemist/mutate"
+  },
+  cartographer: {
+    pathmap: "/summon/cartographer/pathmap"
+  },
+  builder: {
+    frontendshape: "/summon/builder/frontend"
+  }
+};


### PR DESCRIPTION
## Summary
- add companion manifest JSON describing available companions
- define companion route mapping
- scaffold invoke modal for selecting a companion

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6842f6f0d3448332bb10f58672bbdd2c