### PR TITLE
Add FMC and CCC invocation sections

### DIFF
--- a/src/pages/companions/ccc.tsx
+++ b/src/pages/companions/ccc.tsx
@@ -1,8 +1,8 @@
-import { GetStaticProps, GetStaticPaths } from 'next';
 import Head from 'next/head';
 import { companions, Companion } from '@/data/companions';
 
-export default function CompanionPage({ companion }: { companion: Companion }) {
+export default function CCCPage() {
+  const companion: Companion = companions['ccc'];
   return (
     <>
       <Head>
@@ -75,24 +75,27 @@ export default function CompanionPage({ companion }: { companion: Companion }) {
             ))}
           </section>
         )}
+
+        <section className="pt-8 border-t border-gray-300 dark:border-gray-700 space-y-6">
+          <h2 className="text-xl font-semibold text-amber-600 text-center">Summon CCC</h2>
+          <p className="italic text-center text-gray-600 dark:text-gray-400">
+            Begin the ritual — share a grant theme, domain, or desire. The Companion listens with care.
+          </p>
+          <form className="max-w-md mx-auto space-y-4">
+            <label className="block text-sm text-gray-700 dark:text-gray-300 font-medium">
+              Grant Theme or Sector
+              <input type="text" name="grant-theme" className="w-full px-4 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-neutral-800 text-gray-900 dark:text-gray-100" />
+            </label>
+            <label className="block text-sm text-gray-700 dark:text-gray-300 font-medium">
+              Your Offering / Intention
+              <textarea name="intention" rows={4} className="w-full px-4 py-2 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-neutral-800 text-gray-900 dark:text-gray-100" />
+            </label>
+            <button type="submit" className="w-full py-2 bg-amber-600 text-white font-semibold rounded hover:bg-amber-700 transition">
+              Begin the Search
+            </button>
+          </form>
+        </section>
       </main>
     </>
   );
 }
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = Object.keys(companions)
-    .filter((slug) => slug !== 'fmc' && slug !== 'ccc')
-    .map((slug) => ({
-      params: { slug }
-    }));
-  return { paths, fallback: false };
-};
-
-export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const slug = params?.slug as string;
-  const companion = companions[slug];
-  return {
-    props: { companion }
-  };
-};

--- a/src/pages/companions/fmc.tsx
+++ b/src/pages/companions/fmc.tsx
@@ -1,8 +1,8 @@
-import { GetStaticProps, GetStaticPaths } from 'next';
 import Head from 'next/head';
 import { companions, Companion } from '@/data/companions';
 
-export default function CompanionPage({ companion }: { companion: Companion }) {
+export default function FMCPage() {
+  const companion: Companion = companions['fmc'];
   return (
     <>
       <Head>
@@ -75,24 +75,21 @@ export default function CompanionPage({ companion }: { companion: Companion }) {
             ))}
           </section>
         )}
+
+        <section className="pt-8 border-t border-gray-300 dark:border-gray-700 space-y-6">
+          <h2 className="text-xl font-semibold text-amber-600 text-center">Summon FMC</h2>
+          <p className="italic text-center text-gray-600 dark:text-gray-400">
+            A quiet chamber opens. Ask what you need, and the Companion will respond.
+          </p>
+          <div className="w-full h-[600px] rounded-lg overflow-hidden shadow-md">
+            <iframe
+              src="https://your-chat-tool-link.com/fmc"
+              className="w-full h-full border-none"
+              title="Summon FMC"
+            />
+          </div>
+        </section>
       </main>
     </>
   );
 }
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = Object.keys(companions)
-    .filter((slug) => slug !== 'fmc' && slug !== 'ccc')
-    .map((slug) => ({
-      params: { slug }
-    }));
-  return { paths, fallback: false };
-};
-
-export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const slug = params?.slug as string;
-  const companion = companions[slug];
-  return {
-    props: { companion }
-  };
-};


### PR DESCRIPTION
## Summary
- create dedicated pages for `/companions/fmc` and `/companions/ccc`
- insert iframe chat block for FMC
- insert ritual form for CCC
- exclude FMC and CCC from `[slug]` static paths

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6842f92b060483329eaa30463b25fe9e