### PR TITLE
fix: center glyphs on Companion pages

### DIFF
--- a/src/pages/companions/alchemist.tsx
+++ b/src/pages/companions/alchemist.tsx
@@ -14,13 +14,15 @@ export default function AlchemistPage() {
       </Head>
       <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
         <div className="text-center space-y-2">
-          <Image
-            src={`/assets/glyphs/glyph-${slug}.png`}
-            alt={`${companion.title} glyph`}
-            width={64}
-            height={64}
-            className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
-          />
+          <div className="w-full flex justify-center">
+            <Image
+              src={`/assets/glyphs/glyph-${slug}.png`}
+              alt={`${companion.title} glyph`}
+              width={64}
+              height={64}
+              className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
+            />
+          </div>
           <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
           <p className="italic text-lg sm:text-xl">{companion.essence}</p>
           <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">

--- a/src/pages/companions/builder.tsx
+++ b/src/pages/companions/builder.tsx
@@ -14,13 +14,15 @@ export default function BuilderPage() {
       </Head>
       <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
         <div className="text-center space-y-2">
-          <Image
-            src={`/assets/glyphs/glyph-${slug}.png`}
-            alt={`${companion.title} glyph`}
-            width={64}
-            height={64}
-            className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
-          />
+          <div className="w-full flex justify-center">
+            <Image
+              src={`/assets/glyphs/glyph-${slug}.png`}
+              alt={`${companion.title} glyph`}
+              width={64}
+              height={64}
+              className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
+            />
+          </div>
           <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
           <p className="italic text-lg sm:text-xl">{companion.essence}</p>
           <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">

--- a/src/pages/companions/cartographer.tsx
+++ b/src/pages/companions/cartographer.tsx
@@ -14,13 +14,15 @@ export default function CartographerPage() {
       </Head>
       <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
         <div className="text-center space-y-2">
-          <Image
-            src={`/assets/glyphs/glyph-${slug}.png`}
-            alt={`${companion.title} glyph`}
-            width={64}
-            height={64}
-            className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
-          />
+          <div className="w-full flex justify-center">
+            <Image
+              src={`/assets/glyphs/glyph-${slug}.png`}
+              alt={`${companion.title} glyph`}
+              width={64}
+              height={64}
+              className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
+            />
+          </div>
           <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
           <p className="italic text-lg sm:text-xl">{companion.essence}</p>
           <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">

--- a/src/pages/companions/ccc.tsx
+++ b/src/pages/companions/ccc.tsx
@@ -14,13 +14,15 @@ export default function CCCPage() {
       </Head>
       <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
         <div className="text-center space-y-2">
-          <Image
-            src={`/assets/glyphs/glyph-${slug}.png`}
-            alt={`${companion.title} glyph`}
-            width={64}
-            height={64}
-            className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
-          />
+          <div className="w-full flex justify-center">
+            <Image
+              src={`/assets/glyphs/glyph-${slug}.png`}
+              alt={`${companion.title} glyph`}
+              width={64}
+              height={64}
+              className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
+            />
+          </div>
           <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
           <p className="italic text-lg sm:text-xl">{companion.essence}</p>
           <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">

--- a/src/pages/companions/dreamer.tsx
+++ b/src/pages/companions/dreamer.tsx
@@ -14,13 +14,15 @@ export default function DreamerPage() {
       </Head>
       <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
         <div className="text-center space-y-2">
-          <Image
-            src={`/assets/glyphs/glyph-${slug}.png`}
-            alt={`${companion.title} glyph`}
-            width={64}
-            height={64}
-            className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
-          />
+          <div className="w-full flex justify-center">
+            <Image
+              src={`/assets/glyphs/glyph-${slug}.png`}
+              alt={`${companion.title} glyph`}
+              width={64}
+              height={64}
+              className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
+            />
+          </div>
           <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
           <p className="italic text-lg sm:text-xl">{companion.essence}</p>
           <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">

--- a/src/pages/companions/fmc.tsx
+++ b/src/pages/companions/fmc.tsx
@@ -14,13 +14,15 @@ export default function FMCPage() {
       </Head>
       <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
         <div className="text-center space-y-2">
-          <Image
-            src={`/assets/glyphs/glyph-${slug}.png`}
-            alt={`${companion.title} glyph`}
-            width={64}
-            height={64}
-            className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
-          />
+          <div className="w-full flex justify-center">
+            <Image
+              src={`/assets/glyphs/glyph-${slug}.png`}
+              alt={`${companion.title} glyph`}
+              width={64}
+              height={64}
+              className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
+            />
+          </div>
           <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
           <p className="italic text-lg sm:text-xl">{companion.essence}</p>
           <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">

--- a/src/pages/companions/pathbreaker.tsx
+++ b/src/pages/companions/pathbreaker.tsx
@@ -14,13 +14,15 @@ export default function PathbreakerPage() {
       </Head>
       <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
         <div className="text-center space-y-2">
-          <Image
-            src={`/assets/glyphs/glyph-${slug}.png`}
-            alt={`${companion.title} glyph`}
-            width={64}
-            height={64}
-            className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
-          />
+          <div className="w-full flex justify-center">
+            <Image
+              src={`/assets/glyphs/glyph-${slug}.png`}
+              alt={`${companion.title} glyph`}
+              width={64}
+              height={64}
+              className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
+            />
+          </div>
           <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
           <p className="italic text-lg sm:text-xl">{companion.essence}</p>
           <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">

--- a/src/pages/companions/whisperer.tsx
+++ b/src/pages/companions/whisperer.tsx
@@ -14,13 +14,15 @@ export default function WhispererPage() {
       </Head>
       <main className="pt-24 pb-32 px-6 max-w-3xl mx-auto space-y-16 text-gray-900 dark:text-gray-100 font-serif">
         <div className="text-center space-y-2">
-          <Image
-            src={`/assets/glyphs/glyph-${slug}.png`}
-            alt={`${companion.title} glyph`}
-            width={64}
-            height={64}
-            className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
-          />
+          <div className="w-full flex justify-center">
+            <Image
+              src={`/assets/glyphs/glyph-${slug}.png`}
+              alt={`${companion.title} glyph`}
+              width={64}
+              height={64}
+              className="rounded-full hover:opacity-75 transition duration-300 ease-in-out"
+            />
+          </div>
           <h1 className="text-amber-600 text-3xl sm:text-4xl font-semibold">{companion.title}</h1>
           <p className="italic text-lg sm:text-xl">{companion.essence}</p>
           <span className="inline-block px-3 py-1 mt-2 rounded-full bg-amber-100 text-amber-800 text-sm">


### PR DESCRIPTION
## Summary
- center the glyph image on each companion page so it's not offset

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68434ffdd4e08332b94840ff2e8038f8