### PR TITLE
Add theme toggle with next-themes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "@tailwindcss/postcss": "^4.1.8",
     "next": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "next-themes": "latest"
   },
   "devDependencies": {
     "@types/node": "^22.15.29",

--- a/src/components/home/WhisperOfArrival.tsx
+++ b/src/components/home/WhisperOfArrival.tsx
@@ -4,11 +4,13 @@ export default function WhisperOfArrival() {
   return (
     <section
       aria-label="Welcome Invocation"
-      className="flex min-h-screen items-center justify-center bg-gradient-to-b from-white to-slate-100 dark:from-gray-900 dark:to-gray-800 transition-colors ease-in-out duration-500 px-6 sm:px-12 pt-24 pb-32"
+      className="flex min-h-screen items-center justify-center transition-colors duration-500 px-6 sm:px-12 pt-24 pb-32"
     >
-      <h1 className="text-3xl sm:text-4xl md:text-6xl font-serif text-gray-800 dark:text-gray-200 text-center">
-        Welcome, Seeker. Kora is listening.
-      </h1>
+      <div className="bg-white text-black dark:bg-zinc-900 dark:text-white p-8 rounded-md">
+        <h1 className="text-3xl sm:text-4xl md:text-6xl font-serif text-center">
+          Welcome, Seeker. Kora is listening.
+        </h1>
+      </div>
     </section>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,9 +1,13 @@
 import Header from './Header';
 import Footer from './Footer';
+import ThemeToggle from '../ui/ThemeToggle';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col min-h-screen scroll-smooth bg-white dark:bg-neutral-900 font-serif text-gray-800 dark:text-gray-100">
+      <div className="fixed top-4 right-4">
+        <ThemeToggle />
+      </div>
       <Header />
       <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 pt-24 pb-24">
         {children}

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,17 @@
+import { useTheme } from 'next-themes';
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const toggle = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={toggle}
+      className="p-2 rounded transition-colors duration-300 text-gray-800 dark:text-gray-200 hover:opacity-80"
+    >
+      {theme === 'dark' ? '🌞' : '🌙'}
+    </button>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import '../styles/globals.css';
 import type { AppProps } from 'next/app';
 import Layout from '../components/layout/Layout';
+import { ThemeProvider } from 'next-themes';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <Layout>
-      <Component {...pageProps} />
-    </Layout>
+    <ThemeProvider attribute="class">
+      <Layout>
+        <Component {...pageProps} />
+      </Layout>
+    </ThemeProvider>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx}',
     './src/components/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- set `darkMode: 'class'` in Tailwind config
- include `next-themes` as a dependency
- wrap the app with `ThemeProvider`
- add a `ThemeToggle` component
- use the toggle in the site layout
- update `WhisperOfArrival` with themed styling

## Testing
- `npm run build` *(fails: Cannot find module 'next-themes')*

------
https://chatgpt.com/codex/tasks/task_b_68443d16b1808332b9be9f16fbe682dc