### PR TITLE
Add companion suggestions in engine

### DIFF
--- a/src/components/engine/SuggestedCompanions.tsx
+++ b/src/components/engine/SuggestedCompanions.tsx
@@ -1,0 +1,43 @@
+import { motion } from 'framer-motion';
+
+export type CompanionSuggestion = {
+  slug: string;
+  title: string;
+  glyph: string;
+  essence: string;
+  outputs: string[];
+};
+
+export default function SuggestedCompanions({ companions }: { companions: CompanionSuggestion[] }) {
+  return (
+    <section className="space-y-6 mt-8">
+      <h3 className="text-2xl font-serif text-center text-amber-700">These Companions have answered your call</h3>
+      <div className="grid gap-6 sm:grid-cols-2">
+        {companions.map((companion) => (
+          <motion.div
+            key={companion.slug}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: 0.1 }}
+            className="p-4 border border-amber-200 bg-white rounded-xl shadow-md space-y-2"
+          >
+            <div className="text-3xl">{companion.glyph}</div>
+            <h4 className="text-lg font-bold text-gray-800">{companion.title}</h4>
+            <p className="text-sm text-gray-600">{companion.essence}</p>
+            <ul className="text-sm text-gray-700 list-disc ml-5">
+              {companion.outputs.map((o, idx) => (
+                <li key={idx}>{o}</li>
+              ))}
+            </ul>
+            <a
+              href={`/companions/${companion.slug}`}
+              className="inline-block mt-2 text-amber-700 font-semibold hover:underline"
+            >
+              Invoke {companion.title} →
+            </a>
+          </motion.div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/pages/engine.tsx
+++ b/src/pages/engine.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import Head from 'next/head';
 import { motion, AnimatePresence } from 'framer-motion';
+import SuggestedCompanions, { CompanionSuggestion } from '@/components/engine/SuggestedCompanions';
 
 export default function CompanionEngine() {
   const [started, setStarted] = useState(false);
@@ -9,6 +10,7 @@ export default function CompanionEngine() {
     need: '',
     feel: ''
   });
+  const [suggestedCompanions, setSuggestedCompanions] = useState<CompanionSuggestion[]>([]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -48,13 +50,14 @@ export default function CompanionEngine() {
           )}
 
           {started && (
-            <motion.div
-              key="form"
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0 }}
-              className="bg-white/90 p-6 rounded-xl shadow-lg max-w-xl w-full space-y-6"
-            >
+            <>
+              <motion.div
+                key="form"
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0 }}
+                className="bg-white/90 p-6 rounded-xl shadow-lg max-w-xl w-full space-y-6"
+              >
               <h2 className="text-2xl font-semibold text-amber-700 font-serif text-center">Ritual Intake</h2>
 
               <label className="block text-gray-700 text-sm font-medium">
@@ -98,13 +101,34 @@ export default function CompanionEngine() {
                 />
               </label>
 
-              <motion.button
-                onClick={() => alert('Send to n8n webhook →')}
-                className="bg-amber-700 text-white font-semibold px-5 py-2 rounded-md hover:bg-amber-800 transition w-full"
-              >
-                Reflect and Continue →
-              </motion.button>
-            </motion.div>
+                <motion.button
+                  onClick={() =>
+                    setSuggestedCompanions([
+                      {
+                        slug: 'ccc',
+                        title: 'CCC',
+                        glyph: '🧱',
+                        essence: 'Commercial Mirror. Grant Deck Guide.',
+                        outputs: ['Grant Deck', 'Pricing Scroll']
+                      },
+                      {
+                        slug: 'whisperer',
+                        title: 'The Whisperer',
+                        glyph: '🌀',
+                        essence: 'Listens into emotional tone.',
+                        outputs: ['Tone Audit', 'Whisper Codex']
+                      }
+                    ])
+                  }
+                  className="bg-amber-700 text-white font-semibold px-5 py-2 rounded-md hover:bg-amber-800 transition w-full"
+                >
+                  Reflect and Continue →
+                </motion.button>
+              </motion.div>
+              {suggestedCompanions.length > 0 && (
+                <SuggestedCompanions companions={suggestedCompanions} />
+              )}
+            </>
           )}
         </AnimatePresence>
       </main>


### PR DESCRIPTION
## Summary
- add new `SuggestedCompanions` component to show recommended companions
- integrate component into `/engine` page
- show mocked suggestions after form submission

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68472b08644483329c8a0bbc425f0611