### PR TITLE
Add Companion Engine route links

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 export default function Footer() {
   return (
@@ -11,6 +12,11 @@ export default function Footer() {
         className="mx-auto mb-2 opacity-90 hover:opacity-100 transition-opacity max-h-10"
       />
       <p className="text-xs text-center mt-4">Paths Unknown</p>
+      <div className="mt-2">
+        <Link href="/engine" className="text-sm text-amber-600 hover:underline">
+          Explore the Companion Engine
+        </Link>
+      </div>
       <p>Rooted in myth. Guided by listening.</p>
       <p className="text-xs mt-1">A project of Paths Unknown</p>
     </footer>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -59,6 +59,7 @@ export default function Header() {
           <Link href="/">Home</Link>
           <Link href="/our-story">Our Story</Link>
           <Link href="/companions">Meet the Companions</Link>
+          <Link href="/engine" className="text-amber-700 font-serif hover:underline">Companion Engine</Link>
           <Link href="/dispatch">Dispatch</Link>
           <Link href="/contact" className="inline-block">
             <span className="bg-amber-600 text-white px-3 py-1 rounded hover:bg-amber-700">
@@ -78,6 +79,9 @@ export default function Header() {
             </li>
             <li>
               <Link href="/companions">Meet the Companions</Link>
+            </li>
+            <li>
+              <Link href="/engine" className="text-amber-700 font-serif hover:underline">Companion Engine</Link>
             </li>
             <li>
               <Link href="/dispatch">Dispatch</Link>

--- a/src/pages/companions.tsx
+++ b/src/pages/companions.tsx
@@ -8,6 +8,12 @@ export default function CompanionsPage() {
       <h1 className="text-amber-600 text-3xl sm:text-4xl md:text-5xl font-semibold mb-6">
         The Companions of Kora
       </h1>
+      <Link
+        href="/engine"
+        className="inline-block mt-6 px-5 py-3 bg-amber-600 text-white font-semibold rounded-md hover:bg-amber-700 transition"
+      >
+        Begin My Ritual →
+      </Link>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6 gap-y-8">
         {Object.values(companions).map((companion: Companion) => (
           <Link

--- a/src/pages/engine.tsx
+++ b/src/pages/engine.tsx
@@ -21,8 +21,11 @@ export default function CompanionEngine() {
   return (
     <>
       <Head>
-        <title>Companion Engine – Kora</title>
-        <meta name="description" content="Enter the divining pool. Let the Companion Engine guide your next step." />
+        <title>The Companion Engine – Kainat OS (Early Ritual Prototype)</title>
+        <meta
+          name="description"
+          content="Enter the divining pool. Begin your ritual. The Companion Engine offers soft triage and soul-aligned guidance, powered by Kainat OS."
+        />
       </Head>
 
       <main className="min-h-screen bg-gradient-to-br from-green-900 via-white to-amber-100 flex items-center justify-center p-8">


### PR DESCRIPTION
## Summary
- update `<Head>` meta on `/engine`
- link to Companion Engine from header/nav
- link to Companion Engine from footer
- add CTA button on `/companions` to reach the Companion Engine

## Testing
- `npm run build` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684854e4e824833280127e7131df37b1