### PR TITLE
Add ritual invocation component

### DIFF
--- a/src/components/invocation/CompanionRitual.tsx
+++ b/src/components/invocation/CompanionRitual.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { ritualPrompts } from '@/data/ritualPrompts';
+import { Companion } from '@/data/companions';
+
+interface CompanionRitualProps {
+  companion: Companion;
+}
+
+export default function CompanionRitual({ companion }: CompanionRitualProps) {
+  const prompts = ritualPrompts[companion.slug] || [];
+
+  const initialForm: Record<string, string> = {};
+  prompts.forEach((_, idx) => {
+    initialForm[`q${idx + 1}`] = '';
+  });
+
+  const [form, setForm] = useState<Record<string, string>>(initialForm);
+  const [loading, setLoading] = useState(false);
+  const [whisper, setWhisper] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setWhisper(null);
+    try {
+      const res = await fetch(
+        `https://koraintelligence.app.n8n.cloud/webhook/companion-invoke/${companion.slug}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(form),
+        }
+      );
+      const data = await res.json();
+      setWhisper(typeof data.whisper === 'string' ? data.whisper : String(data));
+    } catch (err) {
+      console.error(err);
+      setError('Ritual failed to return a whisper.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="space-y-4 mt-6">
+      <form onSubmit={handleSubmit} className="space-y-3">
+        {prompts.map((prompt, idx) => (
+          <label key={idx} className="block font-serif text-sm text-gray-700">
+            {prompt}
+            <input
+              type="text"
+              name={`q${idx + 1}`}
+              value={form[`q${idx + 1}`]}
+              onChange={handleChange}
+              className="mt-1 w-full border border-amber-300 rounded px-3 py-2 bg-white shadow-inner"
+              required
+              disabled={loading}
+            />
+          </label>
+        ))}
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700"
+        >
+          {loading ? 'Listening...' : 'Whisper'}
+        </button>
+      </form>
+
+      {error && <p className="text-red-600 font-serif">{error}</p>}
+
+      {whisper && (
+        <div className="bg-amber-50 border-l-4 border-amber-400 p-4 font-serif italic shadow-inner rounded">
+          {whisper}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/data/ritualPrompts.ts
+++ b/src/data/ritualPrompts.ts
@@ -1,0 +1,17 @@
+export const ritualPrompts: Record<string, string[]> = {
+  ccc: [
+    "What are you seeking support with (grant, pricing, contract)?",
+    "What stage is your project at?",
+    "Any specific risks or partner dynamics to consider?"
+  ],
+  fmc: [
+    "Describe your current brand expression.",
+    "What is the emotional gap you feel?",
+    "What kind of growth are you seeking?"
+  ],
+  builder: [
+    "What interface or flow needs shaping?",
+    "What is the tone you want it to hold?",
+    "Do you have a story or sketch to work from?"
+  ]
+};

--- a/src/pages/companions/[slug].tsx
+++ b/src/pages/companions/[slug].tsx
@@ -1,0 +1,72 @@
+import { useRouter } from 'next/router';
+import Head from 'next/head';
+import { companions } from '@/data/companions';
+import CompanionScrollLayout from '@/components/layout/CompanionScrollLayout';
+import CompanionInvocation from '@/components/companions/CompanionInvocation';
+import CompanionRitual from '@/components/invocation/CompanionRitual';
+
+export default function CompanionPage() {
+  const router = useRouter();
+  const { slug } = router.query;
+
+  if (typeof slug !== 'string') {
+    return null;
+  }
+
+  const companion = companions[slug];
+
+  if (!companion) {
+    return <p className="text-center mt-20">Companion not found.</p>;
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{companion.title} – Kora Companion</title>
+        <meta name="description" content={companion.essence} />
+      </Head>
+      <CompanionScrollLayout companion={companion}>
+        {['ccc', 'fmc', 'builder'].includes(companion.slug) && (
+          <CompanionRitual companion={companion} />
+        )}
+        {companion.mode === 'prompt' && companion.questions && companion.webhookUrl && (
+          <CompanionInvocation
+            companionSlug={companion.slug}
+            companionTitle={companion.title}
+            webhookUrl={companion.webhookUrl!}
+            questions={companion.questions}
+          />
+        )}
+        {companion.mode === 'chat' && (
+          <section>
+            <h2 className="text-lg font-semibold text-amber-600 mb-2 text-center">Whisper with {companion.title}</h2>
+            <iframe
+              src="https://chat.openai.com/embed?model=gpt-4"
+              className="w-full h-[500px] border rounded-md"
+            />
+          </section>
+        )}
+        {companion.mode === 'hybrid' && (
+          <section className="space-y-8">
+            <div>
+              <h2 className="text-lg font-semibold text-amber-600 mb-2 text-center">Prompt Summon</h2>
+              <CompanionInvocation
+                companionSlug={companion.slug}
+                companionTitle={companion.title}
+                webhookUrl={companion.webhookUrl!}
+                questions={companion.questions || []}
+              />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-amber-600 mb-2 text-center">Chat with {companion.title}</h2>
+              <iframe
+                src="https://chat.openai.com/embed?model=gpt-4"
+                className="w-full h-[500px] border rounded-md"
+              />
+            </div>
+          </section>
+        )}
+      </CompanionScrollLayout>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add `CompanionRitual` component for webhook-based whispers
- define reusable `ritualPrompts`
- create new dynamic `/companions/[slug]` page and integrate ritual invocation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68496e402e748332ac974561bdc2925d