### PR TITLE
Enhance ritual form & add typing effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "next": "latest",
     "next-themes": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "react-simple-typewriter": "^2.0.1"
   },
   "devDependencies": {
     "@types/node": "^22.15.29",

--- a/src/components/home/WhisperOfArrival.tsx
+++ b/src/components/home/WhisperOfArrival.tsx
@@ -1,5 +1,7 @@
 // src/components/home/WhisperOfArrival.tsx
 
+import { Typewriter } from 'react-simple-typewriter';
+
 export default function WhisperOfArrival() {
   return (
     <section
@@ -8,7 +10,15 @@ export default function WhisperOfArrival() {
     >
       <div className="bg-white text-black dark:bg-zinc-900 dark:text-white p-8 rounded-md">
         <h1 className="text-3xl sm:text-4xl md:text-6xl font-serif text-center">
-          Welcome, Seeker. Kora is listening.
+          <Typewriter
+            words={["Welcome Seeker, Kora is listening"]}
+            loop={false}
+            cursor
+            cursorStyle="."
+            typeSpeed={50}
+            deleteSpeed={0}
+            delaySpeed={1000}
+          />
         </h1>
       </div>
     </section>

--- a/src/components/invocation/CompanionRitual.tsx
+++ b/src/components/invocation/CompanionRitual.tsx
@@ -40,11 +40,23 @@ export default function CompanionRitual({ companion }: CompanionRitualProps) {
           body: JSON.stringify(form),
         }
       );
+
+      if (!res.ok) {
+        let message = `Ritual failed (${res.status})`;
+        if (res.status === 400) {
+          message = 'Some responses were incomplete. Please revise.';
+        } else if (res.status >= 500) {
+          message = 'The spirits misfired. Please try again later.';
+        }
+        setError(message);
+        return;
+      }
+
       const data = await res.json();
       setWhisper(typeof data.whisper === 'string' ? data.whisper : String(data));
     } catch (err) {
       console.error(err);
-      setError('Ritual failed to return a whisper.');
+      setError('A network error disturbed the ritual.');
     } finally {
       setLoading(false);
     }
@@ -61,7 +73,8 @@ export default function CompanionRitual({ companion }: CompanionRitualProps) {
               name={`q${idx + 1}`}
               value={form[`q${idx + 1}`]}
               onChange={handleChange}
-              className="mt-1 w-full border border-amber-300 rounded px-3 py-2 bg-white shadow-inner"
+              placeholder={prompt}
+              className="transition-all duration-300 mt-1 w-full border border-amber-300 rounded px-3 py-2 bg-white shadow-inner placeholder-opacity-0 focus:placeholder-opacity-100 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:border-amber-500"
               required
               disabled={loading}
             />
@@ -70,13 +83,23 @@ export default function CompanionRitual({ companion }: CompanionRitualProps) {
         <button
           type="submit"
           disabled={loading}
-          className="bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700"
+          className="bg-amber-600 text-white px-4 py-2 rounded hover:bg-amber-700 active:bg-amber-800 disabled:bg-amber-300 disabled:cursor-not-allowed transition-colors duration-300"
         >
           {loading ? 'Listening...' : 'Whisper'}
         </button>
       </form>
 
-      {error && <p className="text-red-600 font-serif">{error}</p>}
+      {error && (
+        <div className="text-red-600 font-serif space-y-2">
+          <p>{error}</p>
+          <button
+            onClick={() => setError(null)}
+            className="underline text-sm hover:text-red-700"
+          >
+            Try Again →
+          </button>
+        </div>
+      )}
 
       {whisper && (
         <div className="bg-amber-50 border-l-4 border-amber-400 p-4 font-serif italic shadow-inner rounded">


### PR DESCRIPTION
## Summary
- style ritual form inputs and buttons
- show better status-driven errors with a retry
- animate typed greeting on the homepage
- add `react-simple-typewriter` dependency

## Testing
- `npm run build` *(fails: Cannot find module 'react-simple-typewriter')*

------
https://chatgpt.com/codex/tasks/task_b_68497e5bb8308332a5feb0d2e1aed2ca