### PR TITLE
Fix glyph rendering in chat

### DIFF
--- a/src/components/chat/CompanionChat.tsx
+++ b/src/components/chat/CompanionChat.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
-import { companionSlugs } from '@/data/companions';
 
 // SohbatChalice – Companion chat interface
 
@@ -127,11 +126,10 @@ export default function CompanionChat({ companionSlug, title, apiPath }: Compani
             >
               {msg.sender === 'companion' && (
                 <span className="absolute top-1 right-2 opacity-5">
-                  <Image
+                  <img
                     src={`/assets/glyphs/glyph-${companionSlug}.png`}
                     alt={`${companionSlug} glyph`}
-                    width={24}
-                    height={24}
+                    className="h-6 w-6"
                   />
                 </span>
               )}

--- a/src/pages/companions/[slug]/chat.tsx
+++ b/src/pages/companions/[slug]/chat.tsx
@@ -6,17 +6,27 @@ import Link from 'next/link';
 
 export default function CompanionChatPage() {
   const router = useRouter();
-  const { slug } = router.query;
+  const querySlug = Array.isArray(router.query.slug)
+    ? router.query.slug[0]
+    : router.query.slug;
 
-  if (typeof slug !== 'string') {
-    return <div className="text-center mt-20 text-amber-600">Whispering paths are unclear...</div>;
+  if (typeof querySlug !== 'string') {
+    return (
+      <div className="text-center mt-20 text-amber-600">
+        Whispering paths are unclear...
+      </div>
+    );
   }
+
+  const slug = querySlug;
 
   const companion = companions[slug];
 
   if (!companion) {
     return <div className="text-center mt-20 text-red-600">This Companion has yet to be summoned.</div>;
   }
+
+  const glyphPath = `/assets/glyphs/glyph-${slug}.png`;
 
   return (
     <>
@@ -28,13 +38,11 @@ export default function CompanionChatPage() {
       <main className="min-h-screen bg-gradient-to-b from-amber-50 to-white dark:from-zinc-800 dark:to-zinc-900 px-4 sm:px-8 py-10">
         <div className="max-w-4xl mx-auto space-y-8">
           <div className="text-center">
-            {companion.glyph && (
-              <img
-                src={companion.glyph}
-                alt={`${companion.title} glyph`}
-                className="mx-auto h-12 w-12 mb-3 opacity-90"
-              />
-            )}
+            <img
+              src={glyphPath}
+              alt={`${companion.title} glyph`}
+              className="mx-auto h-12 w-12 mb-3 opacity-90"
+            />
             <h1 className="text-2xl sm:text-3xl font-serif text-amber-700 dark:text-amber-300">
               Whisper with {companion.title}
             </h1>


### PR DESCRIPTION
## Summary
- show slug images in `<CompanionChat>` with `<img>` for reliability
- handle dynamic slug in `[slug]/chat.tsx`
- render glyph by slug on chat page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684ca00b25e08332922680b446fa5192