### PR TITLE
Improve theme toggle and dark mode styling

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+import ThemeToggle from '../ui/ThemeToggle';
 
 export default function Header() {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -18,33 +19,36 @@ export default function Header() {
             Kora Intelligence
           </span>
         </div>
-        <button
-          className="sm:hidden text-gray-800 dark:text-gray-200"
-          onClick={() => setMobileOpen(!mobileOpen)}
-          aria-label="Toggle navigation menu"
-        >
-          {mobileOpen ? (
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          ) : (
-            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-            </svg>
-          )}
-        </button>
-        <div className="hidden sm:flex space-x-6 text-sm font-medium text-gray-800 dark:text-gray-200">
-          <Link href="/">Home</Link>
-          <Link href="/our-story">Our Story</Link>
-          <Link href="/companions">Meet the Companions</Link>
-          <Link href="/engine" className="text-amber-700 font-serif hover:underline">Companion Engine</Link>
-          <Link href="/labs" className="font-ritual hover:text-amber-700 dark:hover:text-amber-300 transition">Labs</Link>
-          <Link href="/dispatch">Dispatch</Link>
-          <Link href="/contact" className="inline-block">
-            <span className="bg-amber-600 text-white px-3 py-1 rounded hover:bg-amber-700">
-              Begin Your Journey
-            </span>
-          </Link>
+        <div className="flex items-center space-x-4">
+          <ThemeToggle />
+          <button
+            className="sm:hidden text-gray-800 dark:text-gray-200"
+            onClick={() => setMobileOpen(!mobileOpen)}
+            aria-label="Toggle navigation menu"
+          >
+            {mobileOpen ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            )}
+          </button>
+          <div className="hidden sm:flex space-x-6 text-sm font-medium text-gray-800 dark:text-gray-200">
+            <Link href="/">Home</Link>
+            <Link href="/our-story">Our Story</Link>
+            <Link href="/companions">Meet the Companions</Link>
+            <Link href="/engine" className="text-amber-700 font-serif hover:underline">Companion Engine</Link>
+            <Link href="/labs" className="font-ritual hover:text-amber-700 dark:hover:text-amber-300 transition">Labs</Link>
+            <Link href="/dispatch">Dispatch</Link>
+            <Link href="/contact" className="inline-block">
+              <span className="bg-amber-600 text-white px-3 py-1 rounded hover:bg-amber-700">
+                Begin Your Journey
+              </span>
+            </Link>
+          </div>
         </div>
       </div>
       {mobileOpen && (

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,13 +1,9 @@
 import Header from './Header';
 import Footer from './Footer';
-import ThemeToggle from '../ui/ThemeToggle';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col min-h-screen scroll-smooth bg-white dark:bg-neutral-900 font-sans text-gray-800 dark:text-gray-100">
-      <div className="fixed top-4 right-4">
-        <ThemeToggle />
-      </div>
       <Header />
       <main className="flex-1 w-full px-4 sm:px-6 pt-24 pb-24">
         {children}

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,17 +1,54 @@
 import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
 
 export default function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
 
-  const toggle = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const isDark = resolvedTheme === 'dark';
 
   return (
     <button
-      aria-label="Toggle theme"
-      onClick={toggle}
-      className="p-2 rounded transition-colors duration-300 text-gray-800 dark:text-gray-200 hover:opacity-80"
+      aria-label="Toggle dark mode"
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      className="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-700 transition-colors"
     >
-      {theme === 'dark' ? '🌞' : '🌙'}
+      <span className="sr-only">Toggle dark mode</span>
+      <span className="absolute left-1 text-yellow-500">
+        <svg
+          className="h-4 w-4"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 3v2m0 14v2m9-9h-2M5 12H3m15.364-6.364l-1.414 1.414M6.05 17.95l-1.414 1.414M17.95 17.95l1.414 1.414M6.05 6.05L4.636 4.636M12 8a4 4 0 100 8 4 4 0 000-8z"
+          />
+        </svg>
+      </span>
+      <span className="absolute right-1 text-yellow-300">
+        <svg
+          className="h-4 w-4"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+        </svg>
+      </span>
+      <span
+        className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform ${
+          isDark ? 'translate-x-5' : 'translate-x-1'
+        }`}
+      />
     </button>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -104,3 +104,14 @@ body {
 .glyph-watermark {
   @apply absolute opacity-5 top-1 right-2 w-6 h-6 pointer-events-none;
 }
+
+/* Dark mode readability improvements */
+.dark input,
+.dark textarea,
+.dark select {
+  @apply bg-neutral-800 border-gray-600 text-gray-100 placeholder-gray-400;
+}
+
+.dark .prose {
+  @apply text-gray-100;
+}


### PR DESCRIPTION
## Summary
- replace emoji theme toggle with icon-based switch
- move theme toggle into header so it sits beside the menu button
- remove old fixed toggle from layout
- adjust inputs and prose for better dark-mode contrast

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_684e9c04ccec8332b5f346b45d70dabb